### PR TITLE
Pulp CentOS stream 8 repository syncing, publishing & distributing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,5 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+ansible/collections/

--- a/README.md
+++ b/README.md
@@ -1,2 +1,30 @@
-# stackhpc-release-train
+# StackHPC Release Train
+
 StackHPC release automation
+
+## Installation
+
+```
+python3 -m venv venv
+source venv/bin/activate
+pip install -U pip
+pip install -r requirements.txt
+ansible-galaxy collection install -r requirements.yml -p ansible/collections
+```
+
+## Usage
+
+Set the admin password:
+```
+export PULP_PASSWORD=<password>
+```
+
+Sync upstream repos.
+```
+ansible-playbook -i ansible/inventory ansible/pulp-repo-sync.yml
+```
+
+Publish repository versions & create distributions.
+```
+ansible-playbook -i ansible/inventory ansible/pulp-repo-publish.yml
+```

--- a/README.md
+++ b/README.md
@@ -12,9 +12,66 @@ pip install -r requirements.txt
 ansible-galaxy collection install -r requirements.yml -p ansible/collections
 ```
 
+## Prerequisites
+
+A Pulp server should be running.
+
+The following procedure can be used to spin up a [Pulp in
+one](https://pulpproject.org/pulp-in-one-container/) 3.11 container.
+
+Why are we using Pulp 3.11? The latest versions of the pulp-rpm plugin have a
+[bug](https://pulp.plan.io/issues/8622) breaks some dependencies in CentOS
+repos. Some
+[discussion](https://app.element.io/?pk_vid=44f328f723e826ef1625565250e6a7ed#/room/#pulp-rpm:matrix.org)
+on the matrix channel.
+
+```
+sudo dnf -y install git vim tmux
+sudo dnf -y install podman
+mkdir settings pulp_storage pgsql containers
+echo "CONTENT_ORIGIN='http://$(hostname):8080'
+ANSIBLE_API_HOSTNAME='http://$(hostname):8080'
+ANSIBLE_CONTENT_HOSTNAME='http://$(hostname):8080/pulp/content'
+TOKEN_AUTH_DISABLED=True" >> settings/settings.py
+podman run --detach              --publish 8080:80              --name pulp              --volume "$(pwd)/settings":/etc/pulp              --volume "$(pwd)/pulp_storage":/var/lib/pulp              --volume "$(pwd)/pgsql":/var/lib/pgsql              --volume "$(pwd)/containers":/var/lib/containers              --device /dev/fuse              pulp/pulp:3.11
+```
+
+Then set an admin password:
+
+```
+podman exec -it pulp bash -c 'pulpcore-manager reset-admin-password'
+```
+
+Install a client:
+
+```
+sudo dnf -y install python3-pip
+pip3 install pulp-cli[pygments] --user
+pulp config create --username admin --base-url http://localhost:8080 --password <password>
+pulp status
+```
+
+There is a [bug](https://pulp.plan.io/issues/8807) in the pulp-rpm plugin
+shipped in the Pulp 3.11 container meaning that it does not work out of the
+box. Fix it up:
+
+```
+podman exec -it pulp bash
+pip install --no-deps 'productmd<1.33'
+cd  /var/run/s6/services
+s6-svc -r new-pulpcore-worker@1
+s6-svc -r new-pulpcore-worker@2
+s6-svc -r pulpcore-api
+s6-svc -r pulpcore-content
+s6-svc -r pulpcore-resource-manager
+s6-svc -r pulpcore-worker@1
+s6-svc -r pulpcore-worker@2
+exit
+```
+
 ## Usage
 
-Set the admin password:
+Set the Pulp admin password:
 ```
 export PULP_PASSWORD=<password>
 ```

--- a/ansible/inventory/group_vars/all/pulp-repos
+++ b/ansible/inventory/group_vars/all/pulp-repos
@@ -25,14 +25,19 @@ pulp_repository_rpm_repos:
     url: https://download.fedoraproject.org/pub/epel/8/Modular/x86_64/
     policy: on_demand
     state: present
+  - name: Docker CE for CentOS 8
+    url: https://download.docker.com/linux/centos/8/x86_64/stable
+    policy: on_demand
+    state: present
+
 
 pulp_publication_rpm:
   - repository: CentOS Stream 8 - BaseOS
     state: present
-    version: 1
+    version: 2
   - repository: CentOS Stream 8 - AppStream
     state: present
-    version: 1
+    version: 2
   - repository: CentOS Stream 8 - Extras
     state: present
     version: 1
@@ -42,26 +47,38 @@ pulp_publication_rpm:
   - repository: Extra Packages for Enterprise Linux Modular 8 - x86_64
     state: present
     version: 1
+  - repository: Docker CE for CentOS 8
+    state: present
+    version: 1
 
-# FIXME: These URL paths are a bit unwieldy.
 pulp_distribution_rpm:
-  - name: CentOS Stream 8 - BaseOS
-    publication: /pulp/api/v3/publications/rpm/rpm/3bbe072a-e63f-4268-8da9-c152a3e0d9f7/
+  - name: centos-stream-8-baseos
+    repository: CentOS Stream 8 - BaseOS
+    version: 2
     base_path: centos/8-stream/BaseOS/x86_64/os
     state: present
-  - name: CentOS Stream 8 - AppStream
-    publication: /pulp/api/v3/publications/rpm/rpm/9b59592c-e74b-4262-9d87-d4dbb7ccdfde/
+  - name: centos-stream-8-appstream
+    repository: CentOS Stream 8 - AppStream
+    version: 2
     base_path: centos/8-stream/AppStream/x86_64/os
     state: present
-  - name: CentOS Stream 8 - Extras
-    publication: /pulp/api/v3/publications/rpm/rpm/bf02e3f3-d28b-4cdc-b12d-74b7c67dd085/
+  - name: centos-stream-8-extras
+    repository: CentOS Stream 8 - Extras
+    version: 1
     base_path: centos/8-stream/extras/x86_64/os
     state: present
-  - name: Extra Packages for Enterprise Linux 8 - x86_64
-    publication: /pulp/api/v3/publications/rpm/rpm/081842b9-a365-477e-bd92-da567035eab8/
+  - name: extra-packages-for-enterprise-linux-8-x86_64
+    repository: Extra Packages for Enterprise Linux 8 - x86_64
+    version: 1
     base_path: epel/8/Everything/x86_64
     state: present
-  - name: Extra Packages for Enterprise Linux 8 Modular - x86_64
-    publication: /pulp/api/v3/publications/rpm/rpm/590a1ff6-86c7-44e3-bb3c-98a0d71aa99a/
+  - name: extra-packages-for-enterprise-linux-modular-8-x86_64
+    repository: Extra Packages for Enterprise Linux Modular 8 - x86_64
+    version: 1
     base_path: epel/8/Modular/x86_64
+    state: present
+  - name: docker-ce-for-centos-8
+    repository: Docker CE for CentOS 8
+    version: 1
+    base_path: docker-ce/centos/8/x86_64/stable
     state: present

--- a/ansible/inventory/group_vars/all/pulp-repos
+++ b/ansible/inventory/group_vars/all/pulp-repos
@@ -1,0 +1,67 @@
+---
+pulp_url: http://localhost:8080
+pulp_username: admin
+pulp_password: "{{ lookup('env', 'PULP_PASSWORD') }}"
+
+# NOTE(mgoddard): mirrorlist as URL did not work.
+pulp_repository_rpm_repos:
+  - name: CentOS Stream 8 - BaseOS
+    url: http://mirrors.vinters.com/centos/8-stream/BaseOS/x86_64/os/
+    policy: on_demand
+    state: present
+  - name: CentOS Stream 8 - AppStream
+    url: http://mirrors.vinters.com/centos/8-stream/AppStream/x86_64/os/
+    policy: on_demand
+    state: present
+  - name: CentOS Stream 8 - Extras
+    url: https://mirrors.vinters.com/centos/8-stream/extras/x86_64/os/
+    policy: on_demand
+    state: present
+  - name: Extra Packages for Enterprise Linux 8 - x86_64
+    url: https://download.fedoraproject.org/pub/epel/8/Everything/x86_64/
+    policy: on_demand
+    state: present
+  - name: Extra Packages for Enterprise Linux Modular 8 - x86_64
+    url: https://download.fedoraproject.org/pub/epel/8/Modular/x86_64/
+    policy: on_demand
+    state: present
+
+pulp_publication_rpm:
+  - repository: CentOS Stream 8 - BaseOS
+    state: present
+    version: 1
+  - repository: CentOS Stream 8 - AppStream
+    state: present
+    version: 1
+  - repository: CentOS Stream 8 - Extras
+    state: present
+    version: 1
+  - repository: Extra Packages for Enterprise Linux 8 - x86_64
+    state: present
+    version: 1
+  - repository: Extra Packages for Enterprise Linux Modular 8 - x86_64
+    state: present
+    version: 1
+
+# FIXME: These URL paths are a bit unwieldy.
+pulp_distribution_rpm:
+  - name: CentOS Stream 8 - BaseOS
+    publication: /pulp/api/v3/publications/rpm/rpm/3bbe072a-e63f-4268-8da9-c152a3e0d9f7/
+    base_path: centos/8-stream/BaseOS/x86_64/os
+    state: present
+  - name: CentOS Stream 8 - AppStream
+    publication: /pulp/api/v3/publications/rpm/rpm/9b59592c-e74b-4262-9d87-d4dbb7ccdfde/
+    base_path: centos/8-stream/AppStream/x86_64/os
+    state: present
+  - name: CentOS Stream 8 - Extras
+    publication: /pulp/api/v3/publications/rpm/rpm/bf02e3f3-d28b-4cdc-b12d-74b7c67dd085/
+    base_path: centos/8-stream/extras/x86_64/os
+    state: present
+  - name: Extra Packages for Enterprise Linux 8 - x86_64
+    publication: /pulp/api/v3/publications/rpm/rpm/081842b9-a365-477e-bd92-da567035eab8/
+    base_path: epel/8/Everything/x86_64
+    state: present
+  - name: Extra Packages for Enterprise Linux 8 Modular - x86_64
+    publication: /pulp/api/v3/publications/rpm/rpm/590a1ff6-86c7-44e3-bb3c-98a0d71aa99a/
+    base_path: epel/8/Modular/x86_64
+    state: present

--- a/ansible/inventory/hosts
+++ b/ansible/inventory/hosts
@@ -1,0 +1,1 @@
+localhost ansible_connection=local

--- a/ansible/pulp-repo-publish.yml
+++ b/ansible/pulp-repo-publish.yml
@@ -1,0 +1,9 @@
+---
+- name: Publish Pulp repositories
+  hosts: localhost
+  gather_facts: False
+  tasks:
+    - import_role:
+        name: stackhpc.pulp.pulp_publication
+    - import_role:
+        name: stackhpc.pulp.pulp_distribution

--- a/ansible/pulp-repo-publish.yml
+++ b/ansible/pulp-repo-publish.yml
@@ -5,5 +5,6 @@
   tasks:
     - import_role:
         name: stackhpc.pulp.pulp_publication
+
     - import_role:
         name: stackhpc.pulp.pulp_distribution

--- a/ansible/pulp-repo-sync.yml
+++ b/ansible/pulp-repo-sync.yml
@@ -1,0 +1,7 @@
+---
+- name: Sync Pulp repositories
+  hosts: localhost
+  gather_facts: False
+  tasks:
+    - import_role:
+        name: stackhpc.pulp.pulp_repository

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+ansible<3

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,2 +1,4 @@
 collections:
-  - name: stackhpc.pulp
+  - name: https://github.com/stackhpc/ansible-collection-pulp
+    type: git
+    version: pulp_distribution_mark

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,0 +1,2 @@
+collections:
+  - name: stackhpc.pulp


### PR DESCRIPTION
Adds two playbooks.

* pulp-repo-sync.yml: Define repositories and sync with upstream
* pulp-repo-publish.yml: Define publication and distributions of repository versions