### PR TITLE
Remove hard-coded container image promotion tag

### DIFF
--- a/.github/workflows/container-promote.yml
+++ b/.github/workflows/container-promote.yml
@@ -2,6 +2,10 @@
 name: Promote container repositories
 on:
   workflow_dispatch:
+    inputs:
+      tag:
+        description: Container image tag to promote
+        required: true
 
 env:
   ANSIBLE_FORCE_COLOR: True
@@ -32,4 +36,5 @@ jobs:
       run: |
         source venv/bin/activate &&
         ansible-playbook -i ansible/inventory \
-        ansible/dev-pulp-container-promote.yml
+        ansible/dev-pulp-container-promote.yml \
+        -e dev_pulp_repository_container_promotion_tag=${{ github.event.inputs.tag }}

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ then pushed to `ark` under the `stackhpc-dev` namespace.
 * `dev-pulp-container-publish.yml`: Configure access control for development container distributions on `ark`.
 * `test-pulp-container-sync.yml`: Synchronise `test` with container images from `stackhpc-dev` namespace on `ark`.
 * `test-pulp-container-publish.yml`: Create distributions on `test` Pulp server for any new container images.
-* `dev-pulp-container-promote.yml`: Promote a set of container images from `stackhpc-dev` to `stackhpc` namespace. The tag to be promoted is defined via `dev_pulp_repository_container_promotion_tag` in `ansible/inventory/group_vars/all/dev-pulp-containers`.
+* `dev-pulp-container-promote.yml`: Promote a set of container images from `stackhpc-dev` to `stackhpc` namespace. The tag to be promoted is defined via `dev_pulp_repository_container_promotion_tag` which should be specified as an extra variable (`-e`).
 
 ### Other playbooks
 

--- a/ansible/dev-pulp-container-promote.yml
+++ b/ansible/dev-pulp-container-promote.yml
@@ -8,6 +8,13 @@
   hosts: localhost
   gather_facts: false
   tasks:
+    - name: Fail if container image to promote is not defined
+      fail:
+        msg: >
+          The container image to promote must be specified via
+          'dev_pulp_repository_container_promotion_tag'
+      when: dev_pulp_repository_container_promotion_tag is not defined
+
     - import_role:
         name: stackhpc.pulp.pulp_repository
       vars:

--- a/ansible/inventory/group_vars/all/dev-pulp-containers
+++ b/ansible/inventory/group_vars/all/dev-pulp-containers
@@ -3,13 +3,14 @@
 dev_release_pulp_registry_url: "{{ dev_pulp_url }}"
 
 # Name of a tag to promote to a release.
-dev_pulp_repository_container_promotion_tag: wallaby-20211210T140839
+# This must be defined when promoting images.
+#dev_pulp_repository_container_promotion_tag:
 
 # Common parameters for release image repositories.
 dev_pulp_repository_container_repo_release_common:
   url: "{{ dev_release_pulp_registry_url }}"
   include_tags:
-    - "{{ dev_pulp_repository_container_promotion_tag }}"
+    - "{{ dev_pulp_repository_container_promotion_tag | mandatory }}"
   policy: on_demand
   remote_username: "{{ dev_pulp_username }}"
   remote_password: "{{ dev_pulp_password }}"


### PR DESCRIPTION
The tag must now be specified via 'dev_pulp_repository_container_promotion_tag'.

Updates the Github workflow to take this as an input.