### PR TITLE
Refactor package repository configuration

### DIFF
--- a/ansible/inventory/group_vars/all/dev-pulp-repos
+++ b/ansible/inventory/group_vars/all/dev-pulp-repos
@@ -1,160 +1,25 @@
 ---
-dev_pulp_repository_rpm_repos:
-  # Base CentOS 8 Stream repositories
-  - name: CentOS Stream 8 - AppStream
-    url: http://mirrorlist.centos.org/?release=8-stream&arch=x86_64&repo=AppStream&infra=genclo
-    policy: immediate
-    sync_policy: mirror_complete
-    state: present
-  - name: CentOS Stream 8 - BaseOS
-    url: http://mirrorlist.centos.org/?release=8-stream&arch=x86_64&repo=BaseOS&infra=genclo
-    policy: immediate
-    sync_policy: mirror_complete
-    state: present
-  - name: CentOS Stream 8 - Extras
-    url: http://mirrorlist.centos.org/?release=8-stream&arch=x86_64&repo=extras&infra=genclo
-    policy: immediate
-    sync_policy: mirror_complete
-    state: present
+# Common parameters for RPM package repositories.
+dev_pulp_repository_rpm_repo_common:
+  # Download all content from upstream mirror immediately, in case it gets removed.
+  policy: immediate
+  # Remove content that has been removed from the upstream mirror.
+  sync_policy: mirror_complete
+  state: present
 
-  # Additional CentOS 8 Stream repositories
-  - name: CentOS Stream 8 - Advanced Virtualization
-    url: http://mirrorlist.centos.org/?release=8-stream&arch=x86_64&repo=virt-advancedvirt-common
-    policy: immediate
-    sync_policy: mirror_complete
-    state: present
-  - name: CentOS Stream 8 - Ceph Pacific
-    url: http://mirrorlist.centos.org/?release=8-stream&arch=x86_64&repo=storage-ceph-pacific
-    policy: immediate
-    sync_policy: mirror_complete
-    state: present
-  - name: CentOS Stream 8 - NFV OpenvSwitch
-    url: http://mirrorlist.centos.org/?release=8-stream&arch=x86_64&repo=nfv-openvswitch-2
-    policy: immediate
-    sync_policy: mirror_complete
-    state: present
-  - name: CentOS Stream 8 - OpenStack Wallaby
-    url: http://mirrorlist.centos.org/?release=8-stream&arch=x86_64&repo=cloud-openstack-wallaby
-    policy: immediate
-    sync_policy: mirror_complete
-    state: present
-  - name: CentOS Stream 8 - PowerTools
-    url: http://mirrorlist.centos.org/?release=8-stream&arch=x86_64&repo=PowerTools&infra=genclo
-    policy: immediate
-    sync_policy: mirror_complete
-    state: present
-
-  # Base CentOS 8 Linux repositories
-  - name: CentOS Linux 8 - AppStream
-    url: http://mirrorlist.centos.org/?release=8&arch=x86_64&repo=AppStream&infra=genclo
-    policy: immediate
-    sync_policy: mirror_complete
-    state: present
-  - name: CentOS Linux 8 - BaseOS
-    url: http://mirrorlist.centos.org/?release=8&arch=x86_64&repo=BaseOS&infra=genclo
-    policy: immediate
-    sync_policy: mirror_complete
-    state: present
-  - name: CentOS Linux 8 - Extras
-    url: http://mirrorlist.centos.org/?release=8&arch=x86_64&repo=extras&infra=genclo
-    policy: immediate
-    sync_policy: mirror_complete
-    state: present
-
-  # Additional CentOS 8 Linux repositories (used by Stream builds)
-  - name: CentOS 8 - Ceph Nautilus
-    url: http://mirrorlist.centos.org/?release=8&arch=x86_64&repo=storage-ceph-nautilus
-    policy: immediate
-    sync_policy: mirror_complete
-    state: present
-  # Note(piotrp): Assuming we'd need this in the future
-  - name: CentOS 8 - Ceph Octopus
-    url: http://mirrorlist.centos.org/?release=8&arch=x86_64&repo=storage-ceph-octopus
-    policy: immediate
-    sync_policy: mirror_complete
-    state: absent
-  - name: CentOS 8 - OpsTools - collectd
-    url: http://mirrorlist.centos.org/?arch=x86_64&release=8&repo=opstools-collectd-5
-    policy: immediate
-    sync_policy: mirror_complete
-    state: present
-
-  # Additional CentOS 8 Linux repositories (not used by Stream builds)
-  - name: CentOS-8 - Advanced Virtualization
-    url: http://mirrorlist.centos.org/?release=8&arch=x86_64&repo=virt-advanced-virtualization
-    policy: immediate
-    sync_policy: mirror_complete
-    state: present
-  - name: CentOS-8 - NFV OpenvSwitch
-    url: http://mirrorlist.centos.org/?release=8&arch=x86_64&repo=nfv-openvswitch-2
-    policy: immediate
-    sync_policy: mirror_complete
-    state: present
-  - name: CentOS-8 - OpenStack Ussuri
-    url: http://mirrorlist.centos.org/?release=8&arch=x86_64&repo=cloud-openstack-ussuri
-    policy: immediate
-    sync_policy: mirror_complete
-    state: present
-  - name: CentOS-8 - OpenStack Victoria
-    url: http://mirrorlist.centos.org/?release=8&arch=x86_64&repo=cloud-openstack-victoria
-    policy: immediate
-    sync_policy: mirror_complete
-    state: present
-  - name: CentOS Linux 8 - PowerTools
-    url: http://mirrorlist.centos.org/?release=8&arch=x86_64&repo=PowerTools&infra=genclo
-    policy: immediate
-    sync_policy: mirror_complete
-    state: present
-
-  # EPEL repositories
-  - name: Extra Packages for Enterprise Linux 8 - x86_64
-    url: https://mirrors.fedoraproject.org/mirrorlist?repo=epel-8&arch=x86_64&infra=stock&content=centos
-    policy: immediate
-    # mirror_complete fails with:
-    # "This repository uses features which are incompatible with 'mirror' sync. Please sync without mirroring enabled"
-    sync_policy: mirror_content_only
-    state: present
-  - name: Extra Packages for Enterprise Linux Modular 8 - x86_64
-    url: https://mirrors.fedoraproject.org/mirrorlist?repo=epel-modular-8&arch=x86_64&infra=stock&content=centos
-    policy: immediate
-    sync_policy: mirror_complete
-    state: present
-
-  # Third-party repositories
-  - name: Docker CE for CentOS 8
-    url: https://download.docker.com/linux/centos/8/x86_64/stable
-    policy: immediate
-    sync_policy: mirror_complete
-    state: present
-  # Note(piotrp): With repository size of 39G - for now we'll want this on_demand
-  - name: ELK repository for 7.x packages
-    url: https://artifacts.elastic.co/packages/oss-7.x/yum
-    policy: on_demand
-    state: present
-  # Note(piotrp): With repository size of 16G - for now we'll want this on_demand
-  - name: Grafana
-    url: https://packages.grafana.com/oss/rpm
-    policy: on_demand
-    state: present
-  - name: RabbitMQ - Erlang
-    url: https://packagecloud.io/rabbitmq/erlang/el/8/x86_64
-    policy: immediate
-    # mirror_complete fails with:
-    # "This repository uses features which are incompatible with 'mirror' sync. Please sync without mirroring enabled"
-    sync_policy: mirror_content_only
-    state: present
-  - name: RabbitMQ - Server
-    url: https://packagecloud.io/rabbitmq/rabbitmq-server/el/8/x86_64
-    policy: immediate
-    # mirror_complete fails with:
-    # "This repository uses features which are incompatible with 'mirror' sync. Please sync without mirroring enabled"
-    sync_policy: mirror_content_only
-    state: present
-  - name: TreasureData 4
-    url: http://packages.treasuredata.com/4/redhat/8/x86_64
-    policy: immediate
-    sync_policy: mirror_complete
-    state: present
+dev_pulp_repository_rpm_repos: >-
+  {%- set dev_repos = [] -%}
+  {%- for repo in rpm_package_repos -%}
+  {%- set dev_repo = {"name": repo.name, "url": repo.url} -%}
+  {%- if "policy" in repo -%}
+  {%- set dev_repo = dev_repo | combine({"policy": repo.policy}) -%}
+  {%- endif -%}
+  {%- if "sync_policy" in repo -%}
+  {%- set dev_repo = dev_repo | combine({"sync_policy": repo.sync_policy}) -%}
+  {%- endif -%}
+  {%- set _ = dev_repos.append(dev_pulp_repository_rpm_repo_common | combine(dev_repo)) -%}
+  {%- endfor -%}
+  {{ dev_repos }}
 
 # Publication format is a subset of distribution.
 dev_pulp_publication_rpm: "{{ dev_pulp_distribution_rpm }}"
@@ -173,151 +38,26 @@ dev_pulp_distribution_version: "{{ ansible_date_time.iso8601_basic_short }}"
 # Whether to promote development distributions to release.
 dev_pulp_distribution_promote: false
 
-dev_pulp_repo_centos_8_opstools_version: "{{ test_pulp_repo_centos_8_opstools_version if dev_pulp_distribution_promote | bool else dev_pulp_distribution_version }}"
-dev_pulp_repo_centos_8_storage_ceph_nautilus_version: "{{ test_pulp_repo_centos_8_storage_ceph_nautilus_version if dev_pulp_distribution_promote | bool else dev_pulp_distribution_version }}"
-dev_pulp_repo_centos_stream_8_advanced_virtualization_version: "{{ test_pulp_repo_centos_stream_8_advanced_virtualization_version if dev_pulp_distribution_promote | bool else dev_pulp_distribution_version }}"
-dev_pulp_repo_centos_stream_8_appstream_version: "{{ test_pulp_repo_centos_stream_8_appstream_version if dev_pulp_distribution_promote | bool else dev_pulp_distribution_version }}"
-dev_pulp_repo_centos_stream_8_baseos_version: "{{ test_pulp_repo_centos_stream_8_baseos_version if dev_pulp_distribution_promote | bool else dev_pulp_distribution_version }}"
-dev_pulp_repo_centos_stream_8_extras_version: "{{ test_pulp_repo_centos_stream_8_extras_version if dev_pulp_distribution_promote | bool else dev_pulp_distribution_version }}"
-dev_pulp_repo_centos_stream_8_nfv_openvswitch_version: "{{ test_pulp_repo_centos_stream_8_nfv_openvswitch_version if dev_pulp_distribution_promote | bool else dev_pulp_distribution_version }}"
-dev_pulp_repo_centos_stream_8_openstack_wallaby_version: "{{ test_pulp_repo_centos_stream_8_openstack_wallaby_version if dev_pulp_distribution_promote | bool else dev_pulp_distribution_version }}"
-dev_pulp_repo_centos_stream_8_powertools_version: "{{ test_pulp_repo_centos_stream_8_powertools_version if dev_pulp_distribution_promote | bool else dev_pulp_distribution_version }}"
-dev_pulp_repo_centos_stream_8_storage_ceph_pacific_version: "{{ test_pulp_repo_centos_stream_8_storage_ceph_pacific_version if dev_pulp_distribution_promote | bool else dev_pulp_distribution_version }}"
-dev_pulp_repo_docker_version: "{{ test_pulp_repo_docker_version if dev_pulp_distribution_promote | bool else dev_pulp_distribution_version }}"
-dev_pulp_repo_elasticsearch_logstash_kibana_7_x_version: "{{ test_pulp_repo_elasticsearch_logstash_kibana_7_x_version if dev_pulp_distribution_promote | bool else dev_pulp_distribution_version }}"
-dev_pulp_repo_epel_modular_version: "{{ test_pulp_repo_epel_modular_version if dev_pulp_distribution_promote | bool else dev_pulp_distribution_version }}"
-dev_pulp_repo_epel_version: "{{ test_pulp_repo_epel_version if dev_pulp_distribution_promote | bool else dev_pulp_distribution_version }}"
-dev_pulp_repo_grafana_version: "{{ test_pulp_repo_grafana_version if dev_pulp_distribution_promote | bool else dev_pulp_distribution_version }}"
-dev_pulp_repo_rabbitmq_erlang_version: "{{ test_pulp_repo_rabbitmq_erlang_version if dev_pulp_distribution_promote | bool else dev_pulp_distribution_version }}"
-dev_pulp_repo_rabbitmq_server_version: "{{ test_pulp_repo_rabbitmq_server_version if dev_pulp_distribution_promote | bool else dev_pulp_distribution_version }}"
-dev_pulp_repo_treasuredata_4_version: "{{ test_pulp_repo_treasuredata_4_version if dev_pulp_distribution_promote | bool else dev_pulp_distribution_version }}"
-
 # Content guard used to protect distributions.
 dev_pulp_distribution_content_guard: "{{ 'release' if dev_pulp_distribution_promote | bool else 'development' }}"
 
-dev_pulp_distribution_rpm:
-  # Base CentOS 8 Stream distributions
-  - name: "centos-stream-8-appstream-{{ dev_pulp_repo_centos_stream_8_appstream_version }}"
-    repository: CentOS Stream 8 - AppStream
-    base_path: "centos/8-stream/AppStream/x86_64/os/{{ dev_pulp_repo_centos_stream_8_appstream_version }}"
-    content_guard: "{{ dev_pulp_distribution_content_guard }}"
-    state: present
-    short_name: centos_stream_8_appstream
-  - name: "centos-stream-8-baseos-{{ dev_pulp_repo_centos_stream_8_baseos_version }}"
-    repository: CentOS Stream 8 - BaseOS
-    base_path: "centos/8-stream/BaseOS/x86_64/os/{{ dev_pulp_repo_centos_stream_8_baseos_version }}"
-    content_guard: "{{ dev_pulp_distribution_content_guard }}"
-    state: present
-    short_name: centos_stream_8_baseos
-  - name: "centos-stream-8-extras-{{ dev_pulp_repo_centos_stream_8_extras_version }}"
-    repository: CentOS Stream 8 - Extras
-    base_path: "centos/8-stream/extras/x86_64/os/{{ dev_pulp_repo_centos_stream_8_extras_version }}"
-    content_guard: "{{ dev_pulp_distribution_content_guard }}"
-    state: present
-    short_name: centos_stream_8_extras
+# Common parameters for RPM package distributions.
+dev_pulp_distribution_rpm_common:
+  content_guard: "{{ dev_pulp_distribution_content_guard }}"
+  state: present
 
-  # Additional CentOS 8 Stream distributions
-  - name: "centos-stream-8-advancedvirt-{{ dev_pulp_repo_centos_stream_8_advanced_virtualization_version }}"
-    repository: CentOS Stream 8 - Advanced Virtualization
-    base_path: "centos/8-stream/virt/x86_64/advancedvirt-common/{{ dev_pulp_repo_centos_stream_8_advanced_virtualization_version }}"
-    content_guard: "{{ dev_pulp_distribution_content_guard }}"
-    state: present
-    short_name: centos_stream_8_advanced_virtualization
-  - name: "centos-stream-8-storage-ceph-pacific-{{ dev_pulp_repo_centos_stream_8_storage_ceph_pacific_version }}"
-    repository: CentOS Stream 8 - Ceph Pacific
-    base_path: "centos/8-stream/storage/x86_64/ceph-pacific/{{ dev_pulp_repo_centos_stream_8_storage_ceph_pacific_version }}"
-    content_guard: "{{ dev_pulp_distribution_content_guard }}"
-    state: present
-    short_name: centos_stream_8_storage_ceph_pacific
-  - name: "centos-stream-8-nfv-openvswitch-{{ dev_pulp_repo_centos_stream_8_nfv_openvswitch_version }}"
-    repository: CentOS Stream 8 - NFV OpenvSwitch
-    base_path: "centos/8-stream/nfv/x86_64/openvswitch-2/{{ dev_pulp_repo_centos_stream_8_nfv_openvswitch_version }}"
-    content_guard: "{{ dev_pulp_distribution_content_guard }}"
-    state: present
-    short_name: centos_stream_8_nfv_openvswitch
-  - name: "centos-stream-8-openstack-wallaby-{{ dev_pulp_repo_centos_stream_8_openstack_wallaby_version }}"
-    repository: CentOS Stream 8 - OpenStack Wallaby
-    base_path: "centos/8-stream/cloud/x86_64/openstack-wallaby/{{ dev_pulp_repo_centos_stream_8_openstack_wallaby_version }}"
-    content_guard: "{{ dev_pulp_distribution_content_guard }}"
-    state: present
-    short_name: centos_stream_8_openstack_wallaby
-  - name: "centos-stream-8-powertools-{{ dev_pulp_repo_centos_stream_8_powertools_version }}"
-    repository: CentOS Stream 8 - PowerTools
-    base_path: "centos/8-stream/PowerTools/x86_64/os/{{ dev_pulp_repo_centos_stream_8_powertools_version }}"
-    content_guard: "{{ dev_pulp_distribution_content_guard }}"
-    state: present
-    short_name: centos_stream_8_powertools
-  - name: "centos-8-opstools-{{ dev_pulp_repo_centos_8_opstools_version }}"
-    repository: CentOS 8 - OpsTools - collectd
-    base_path: "centos/8/opstools/x86_64/collectd-5/{{ dev_pulp_repo_centos_8_opstools_version }}"
-    content_guard: "{{ dev_pulp_distribution_content_guard }}"
-    state: present
-    short_name: centos_8_opstools
-  - name: "centos-8-storage-ceph-nautilus-{{ dev_pulp_repo_centos_8_storage_ceph_nautilus_version }}"
-    repository: CentOS 8 - Ceph Nautilus
-    base_path: "centos/8/storage/x86_64/ceph-nautilus/{{ dev_pulp_repo_centos_8_storage_ceph_nautilus_version }}"
-    content_guard: "{{ dev_pulp_distribution_content_guard }}"
-    state: present
-    short_name: centos_8_storage_ceph_nautilus
-  # Note(piotrp): Assuming we'd need this in the future
-  # - name: "centos-8-storage-ceph-octopus-{{ dev_pulp_repo_centos_8_storage_ceph_octopus_version }}"
-  #   repository: CentOS 8 - Ceph Octopus
-  #   base_path: "centos/8/storage/x86_64/ceph-octopus/{{ dev_pulp_repo_centos_8_storage_ceph_octopus_version }}"
-  #   content_guard: "{{ dev_pulp_distribution_content_guard }}"
-  #   state: present
-  #   short_name: centos_8_storage_ceph_octopus
-
-  # EPEL distributions
-  - name: "extra-packages-for-enterprise-linux-8-x86_64-{{ dev_pulp_repo_epel_version }}"
-    repository: Extra Packages for Enterprise Linux 8 - x86_64
-    base_path: "epel/8/Everything/x86_64/{{ dev_pulp_repo_epel_version }}"
-    content_guard: "{{ dev_pulp_distribution_content_guard }}"
-    state: present
-    short_name: epel
-  - name: "extra-packages-for-enterprise-linux-modular-8-x86_64-{{ dev_pulp_repo_epel_modular_version }}"
-    repository: Extra Packages for Enterprise Linux Modular 8 - x86_64
-    base_path: "epel/8/Modular/x86_64/{{ dev_pulp_repo_epel_modular_version }}"
-    content_guard: "{{ dev_pulp_distribution_content_guard }}"
-    state: present
-    short_name: epel_modular
-
-  # Third-party distributions
-  - name: "docker-ce-for-centos-8-{{ dev_pulp_repo_docker_version }}"
-    repository: Docker CE for CentOS 8
-    base_path: "docker-ce/centos/8/x86_64/stable/{{ dev_pulp_repo_docker_version }}"
-    content_guard: "{{ dev_pulp_distribution_content_guard }}"
-    state: present
-    short_name: docker
-  - name: "elasticsearch-logstash-kibana-7.x-{{ dev_pulp_repo_elasticsearch_logstash_kibana_7_x_version }}"
-    repository: ELK repository for 7.x packages
-    base_path: "elasticsearch/oss-7.x/{{ dev_pulp_repo_elasticsearch_logstash_kibana_7_x_version }}"
-    content_guard: "{{ dev_pulp_distribution_content_guard }}"
-    state: present
-    short_name: elasticsearch_logstash_kibana_7_x
-  - name: "grafana-{{ dev_pulp_repo_grafana_version }}"
-    repository: Grafana
-    base_path: "grafana/oss/rpm/{{ dev_pulp_repo_grafana_version }}"
-    content_guard: "{{ dev_pulp_distribution_content_guard }}"
-    state: present
-    short_name: grafana
-  - name: "rabbitmq-erlang-{{ dev_pulp_repo_rabbitmq_erlang_version }}"
-    repository: RabbitMQ - Erlang
-    base_path: "rabbitmq/erlang/el/8/x86_64/{{ dev_pulp_repo_rabbitmq_erlang_version }}"
-    content_guard: "{{ dev_pulp_distribution_content_guard }}"
-    state: present
-    short_name: rabbitmq_erlang
-  - name: "rabbitmq-server-{{ dev_pulp_repo_rabbitmq_server_version }}"
-    repository: RabbitMQ - Server
-    base_path: "rabbitmq/rabbitmq-server/el/8/x86_64/{{ dev_pulp_repo_rabbitmq_server_version }}"
-    content_guard: "{{ dev_pulp_distribution_content_guard }}"
-    state: present
-    short_name: rabbitmq_server
-  - name: "treasuredata-4-{{ dev_pulp_repo_treasuredata_4_version }}"
-    repository: TreasureData 4
-    base_path: "treasuredata/4/redhat/8/x86_64/{{ dev_pulp_repo_treasuredata_4_version }}"
-    content_guard: "{{ dev_pulp_distribution_content_guard }}"
-    state: present
-    short_name: treasuredata_4
+dev_pulp_distribution_rpm: >-
+  {%- set dev_dists = [] -%}
+  {%- for repo in rpm_package_repos -%}
+  {%- if repo.publish | default(true) -%}
+  {%- set version = (repo.version if dev_pulp_distribution_promote | bool else dev_pulp_distribution_version) -%}
+  {%- set name = repo.distribution_name ~ version -%}
+  {%- set base_path = repo.base_path ~ version -%}
+  {%- set dev_dist = {"name": name, "repository": repo.name, "base_path": base_path, "short_name": repo.short_name} -%}
+  {%- set _ = dev_dists.append(dev_pulp_distribution_rpm_common | combine(dev_dist)) -%}
+  {%- endif -%}
+  {%- endfor -%}
+  {{ dev_dists }}
 
 # Whether to skip existing RPM distributions. If true, new distributions will
 # not be created for a publication if any distributions exist for the same

--- a/ansible/inventory/group_vars/all/package-repos
+++ b/ansible/inventory/group_vars/all/package-repos
@@ -1,0 +1,175 @@
+---
+# List of package repositories.
+# Each item is a dict with the following items:
+# name: Repository name.
+# url: URL of upstream package mirror.
+# policy: Policy for upstream remote. Optional.
+# sync_policy: Sync policy for upstream remote. Optional.
+# base_path: Base path prefix for distributions.
+# short_name: Name used internally for variable names.
+# distribution_name: Name prefix for distributions. Version will be appended.
+# version: Version to sync/promote.
+# publish: Whether to publish and distribute the repository. Optional, default is true.
+rpm_package_repos:
+  # Base CentOS 8 Stream repositories
+  - name: CentOS Stream 8 - AppStream
+    url: http://mirrorlist.centos.org/?release=8-stream&arch=x86_64&repo=AppStream&infra=genclo
+    base_path: centos/8-stream/AppStream/x86_64/os/
+    short_name: centos_stream_8_appstream
+    distribution_name: centos-stream-8-appstream-
+    version: "{{ test_pulp_repo_centos_stream_8_appstream_version }}"
+  - name: CentOS Stream 8 - BaseOS
+    url: http://mirrorlist.centos.org/?release=8-stream&arch=x86_64&repo=BaseOS&infra=genclo
+    base_path: centos/8-stream/BaseOS/x86_64/os/
+    short_name: centos_stream_8_baseos
+    distribution_name: centos-stream-8-baseos-
+    version: "{{ test_pulp_repo_centos_stream_8_baseos_version }}"
+  - name: CentOS Stream 8 - Extras
+    url: http://mirrorlist.centos.org/?release=8-stream&arch=x86_64&repo=extras&infra=genclo
+    base_path: centos/8-stream/extras/x86_64/os/
+    short_name: centos_stream_8_extras
+    distribution_name: centos-stream-8-extras-
+    version: "{{ test_pulp_repo_centos_stream_8_extras_version }}"
+
+  # Additional CentOS 8 Stream repositories
+  - name: CentOS Stream 8 - Advanced Virtualization
+    url: http://mirrorlist.centos.org/?release=8-stream&arch=x86_64&repo=virt-advancedvirt-common
+    base_path: centos/8-stream/virt/x86_64/advancedvirt-common/
+    short_name: centos_stream_8_advanced_virtualization
+    distribution_name: centos-stream-8-advancedvirt-
+    version: "{{ test_pulp_repo_centos_stream_8_advanced_virtualization_version }}"
+  - name: CentOS Stream 8 - Ceph Pacific
+    url: http://mirrorlist.centos.org/?release=8-stream&arch=x86_64&repo=storage-ceph-pacific
+    base_path: centos/8-stream/storage/x86_64/ceph-pacific/
+    short_name: centos_stream_8_storage_ceph_pacific
+    distribution_name: centos-stream-8-storage-ceph-pacific-
+    version: "{{ test_pulp_repo_centos_stream_8_storage_ceph_pacific_version }}"
+  - name: CentOS Stream 8 - NFV OpenvSwitch
+    url: http://mirrorlist.centos.org/?release=8-stream&arch=x86_64&repo=nfv-openvswitch-2
+    base_path: centos/8-stream/nfv/x86_64/openvswitch-2/
+    short_name: centos_stream_8_nfv_openvswitch
+    distribution_name: centos-stream-8-nfv-openvswitch-
+    version: "{{ test_pulp_repo_centos_stream_8_nfv_openvswitch_version }}"
+  - name: CentOS Stream 8 - OpenStack Wallaby
+    url: http://mirrorlist.centos.org/?release=8-stream&arch=x86_64&repo=cloud-openstack-wallaby
+    base_path: centos/8-stream/cloud/x86_64/openstack-wallaby/
+    short_name: centos_stream_8_openstack_wallaby
+    distribution_name: centos-stream-8-openstack-wallaby-
+    version: "{{ test_pulp_repo_centos_stream_8_openstack_wallaby_version }}"
+  - name: CentOS Stream 8 - PowerTools
+    url: http://mirrorlist.centos.org/?release=8-stream&arch=x86_64&repo=PowerTools&infra=genclo
+    base_path: centos/8-stream/PowerTools/x86_64/os/
+    short_name: centos_stream_8_powertools
+    distribution_name: centos-stream-8-powertools-
+    version: "{{ test_pulp_repo_centos_stream_8_powertools_version }}"
+
+  # Base CentOS 8 Linux repositories
+  - name: CentOS Linux 8 - AppStream
+    url: http://mirrorlist.centos.org/?release=8&arch=x86_64&repo=AppStream&infra=genclo
+    publish: false
+  - name: CentOS Linux 8 - BaseOS
+    url: http://mirrorlist.centos.org/?release=8&arch=x86_64&repo=BaseOS&infra=genclo
+    publish: false
+  - name: CentOS Linux 8 - Extras
+    url: http://mirrorlist.centos.org/?release=8&arch=x86_64&repo=extras&infra=genclo
+    publish: false
+
+  # Additional CentOS 8 Linux repositories (used by Stream builds)
+  - name: CentOS 8 - Ceph Nautilus
+    url: http://mirrorlist.centos.org/?release=8&arch=x86_64&repo=storage-ceph-nautilus
+    base_path: centos/8/storage/x86_64/ceph-nautilus/
+    short_name: centos_8_storage_ceph_nautilus
+    distribution_name: centos-8-storage-ceph-nautilus-
+    version: "{{ test_pulp_repo_centos_8_storage_ceph_nautilus_version }}"
+  - name: CentOS 8 - Ceph Octopus
+    url: http://mirrorlist.centos.org/?release=8&arch=x86_64&repo=storage-ceph-octopus
+    distribution_name: centos-8-storage-ceph-octopus-
+    publish: false
+  - name: CentOS 8 - OpsTools - collectd
+    url: http://mirrorlist.centos.org/?arch=x86_64&release=8&repo=opstools-collectd-5
+    base_path: centos/8/opstools/x86_64/collectd-5/
+    short_name: centos_8_opstools
+    distribution_name: centos-8-opstools-
+    version: "{{ test_pulp_repo_centos_8_opstools_version }}"
+
+  # Additional CentOS 8 Linux repositories (not used by Stream builds)
+  - name: CentOS-8 - Advanced Virtualization
+    url: http://mirrorlist.centos.org/?release=8&arch=x86_64&repo=virt-advanced-virtualization
+    publish: false
+  - name: CentOS-8 - NFV OpenvSwitch
+    url: http://mirrorlist.centos.org/?release=8&arch=x86_64&repo=nfv-openvswitch-2
+    publish: false
+  - name: CentOS-8 - OpenStack Ussuri
+    url: http://mirrorlist.centos.org/?release=8&arch=x86_64&repo=cloud-openstack-ussuri
+    publish: false
+  - name: CentOS-8 - OpenStack Victoria
+    url: http://mirrorlist.centos.org/?release=8&arch=x86_64&repo=cloud-openstack-victoria
+    publish: false
+  - name: CentOS Linux 8 - PowerTools
+    url: http://mirrorlist.centos.org/?release=8&arch=x86_64&repo=PowerTools&infra=genclo
+    publish: false
+
+  # EPEL repositories
+  - name: Extra Packages for Enterprise Linux 8 - x86_64
+    url: https://mirrors.fedoraproject.org/mirrorlist?repo=epel-8&arch=x86_64&infra=stock&content=centos
+    # mirror_complete fails with:
+    # "This repository uses features which are incompatible with 'mirror' sync. Please sync without mirroring enabled"
+    sync_policy: mirror_content_only
+    base_path: epel/8/Everything/x86_64/
+    short_name: epel
+    distribution_name: extra-packages-for-enterprise-linux-8-x86_64-
+    version: "{{ test_pulp_repo_epel_version }}"
+  - name: Extra Packages for Enterprise Linux Modular 8 - x86_64
+    url: https://mirrors.fedoraproject.org/mirrorlist?repo=epel-modular-8&arch=x86_64&infra=stock&content=centos
+    base_path: epel/8/Modular/x86_64/
+    short_name: epel_modular
+    distribution_name: extra-packages-for-enterprise-linux-modular-8-x86_64-
+    version: "{{ test_pulp_repo_epel_modular_version }}"
+
+  # Third-party repositories
+  - name: Docker CE for CentOS 8
+    url: https://download.docker.com/linux/centos/8/x86_64/stable
+    base_path: docker-ce/centos/8/x86_64/stable/
+    short_name: docker
+    distribution_name: docker-ce-for-centos-8-
+    version: "{{ test_pulp_repo_docker_version }}"
+  # Note(piotrp): With repository size of 39G - for now we'll want this on_demand
+  - name: ELK repository for 7.x packages
+    url: https://artifacts.elastic.co/packages/oss-7.x/yum
+    policy: on_demand
+    base_path: elasticsearch/oss-7.x/
+    short_name: elasticsearch_logstash_kibana_7_x
+    distribution_name: elasticsearch-logstash-kibana-7.x-
+    version: "{{ test_pulp_repo_elasticsearch_logstash_kibana_7_x_version }}"
+  # Note(piotrp): With repository size of 16G - for now we'll want this on_demand
+  - name: Grafana
+    url: https://packages.grafana.com/oss/rpm
+    policy: on_demand
+    base_path: grafana/oss/rpm/
+    short_name: grafana
+    distribution_name: grafana-
+    version: "{{ test_pulp_repo_grafana_version }}"
+  - name: RabbitMQ - Erlang
+    url: https://packagecloud.io/rabbitmq/erlang/el/8/x86_64
+    # mirror_complete fails with:
+    # "This repository uses features which are incompatible with 'mirror' sync. Please sync without mirroring enabled"
+    sync_policy: mirror_content_only
+    base_path: rabbitmq/erlang/el/8/x86_64/
+    short_name: rabbitmq_erlang
+    distribution_name: rabbitmq-erlang-
+    version: "{{ test_pulp_repo_rabbitmq_erlang_version }}"
+  - name: RabbitMQ - Server
+    url: https://packagecloud.io/rabbitmq/rabbitmq-server/el/8/x86_64
+    # mirror_complete fails with:
+    # "This repository uses features which are incompatible with 'mirror' sync. Please sync without mirroring enabled"
+    sync_policy: mirror_content_only
+    base_path: rabbitmq/rabbitmq-server/el/8/x86_64/
+    short_name: rabbitmq_server
+    distribution_name: rabbitmq-server-
+    version: "{{ test_pulp_repo_rabbitmq_server_version }}"
+  - name: TreasureData 4
+    url: http://packages.treasuredata.com/4/redhat/8/x86_64
+    base_path: treasuredata/4/redhat/8/x86_64/
+    short_name: treasuredata_4
+    distribution_name: treasuredata-4-
+    version: "{{ test_pulp_repo_treasuredata_4_version }}"

--- a/ansible/inventory/group_vars/all/test-pulp-repos
+++ b/ansible/inventory/group_vars/all/test-pulp-repos
@@ -1,266 +1,50 @@
 ---
-test_dev_pulp_content_url: "{{ dev_pulp_url }}/pulp/content"
+test_dev_pulp_content_url: "{{ dev_pulp_url }}/pulp/content/"
 
 # Client certificates used to access ark.stackhpc.com repositories.
 # They are trusted by the 'development' cert guard's CA.
 test_client_cert: "{{ lookup('file', '../certs/ark.stackhpc.com/client-cert.pem') | trim }}"
 test_client_key: "{{ lookup('file', '../certs/ark.stackhpc.com/client-key.pem') | trim }}"
 
-# TODO(mgoddard): Use policy=immediate to avoid packages being removed from
-# mirrors.
-test_pulp_repository_rpm_repos:
-  # Base CentOS 8 Stream repositories
-  - name: CentOS Stream 8 - AppStream (ark)
-    url: "{{ test_dev_pulp_content_url }}/centos/8-stream/AppStream/x86_64/os/{{ test_pulp_repo_centos_stream_8_appstream_version }}"
-    client_cert: "{{ test_client_cert }}"
-    client_key: "{{ test_client_key }}"
-    policy: on_demand
-    sync_policy: mirror_complete
-    state: present
-  - name: CentOS Stream 8 - BaseOS (ark)
-    url: "{{ test_dev_pulp_content_url }}/centos/8-stream/BaseOS/x86_64/os/{{ test_pulp_repo_centos_stream_8_baseos_version }}"
-    client_cert: "{{ test_client_cert }}"
-    client_key: "{{ test_client_key }}"
-    policy: on_demand
-    sync_policy: mirror_complete
-    state: present
-  - name: CentOS Stream 8 - Extras (ark)
-    url: "{{ test_dev_pulp_content_url }}/centos/8-stream/extras/x86_64/os/{{ test_pulp_repo_centos_stream_8_extras_version }}"
-    client_cert: "{{ test_client_cert }}"
-    client_key: "{{ test_client_key }}"
-    policy: on_demand
-    sync_policy: mirror_complete
-    state: present
+# Common parameters for RPM package repositories.
+test_pulp_repository_rpm_repo_common:
+  client_cert: "{{ test_client_cert }}"
+  client_key: "{{ test_client_key }}"
+  # Download content on demand from Ark.
+  policy: on_demand
+  # Remove content that has been removed from the upstream mirror.
+  sync_policy: mirror_complete
+  state: present
 
-  # Additional CentOS 8 Stream repositories
-  - name: CentOS Stream 8 - Advanced Virtualization (ark)
-    url: "{{ test_dev_pulp_content_url }}/centos/8-stream/virt/x86_64/advancedvirt-common/{{ test_pulp_repo_centos_stream_8_advanced_virtualization_version }}"
-    client_cert: "{{ test_client_cert }}"
-    client_key: "{{ test_client_key }}"
-    policy: on_demand
-    sync_policy: mirror_complete
-    state: present
-  - name: CentOS Stream 8 - Ceph Pacific (ark)
-    url: "{{ test_dev_pulp_content_url }}/centos/8-stream/storage/x86_64/ceph-pacific/{{ test_pulp_repo_centos_stream_8_storage_ceph_pacific_version }}"
-    client_cert: "{{ test_client_cert }}"
-    client_key: "{{ test_client_key }}"
-    policy: on_demand
-    sync_policy: mirror_complete
-    state: present
-  - name: CentOS Stream 8 - NFV OpenvSwitch (ark)
-    url: "{{ test_dev_pulp_content_url }}/centos/8-stream/nfv/x86_64/openvswitch-2/{{ test_pulp_repo_centos_stream_8_nfv_openvswitch_version }}"
-    client_cert: "{{ test_client_cert }}"
-    client_key: "{{ test_client_key }}"
-    policy: on_demand
-    sync_policy: mirror_complete
-    state: present
-  - name: CentOS Stream 8 - OpenStack Wallaby (ark)
-    url: "{{ test_dev_pulp_content_url }}/centos/8-stream/cloud/x86_64/openstack-wallaby/{{ test_pulp_repo_centos_stream_8_openstack_wallaby_version }}"
-    client_cert: "{{ test_client_cert }}"
-    client_key: "{{ test_client_key }}"
-    policy: on_demand
-    sync_policy: mirror_complete
-    state: present
-  - name: CentOS Stream 8 - PowerTools (ark)
-    url: "{{ test_dev_pulp_content_url }}/centos/8-stream/PowerTools/x86_64/os/{{ test_pulp_repo_centos_stream_8_powertools_version }}"
-    client_cert: "{{ test_client_cert }}"
-    client_key: "{{ test_client_key }}"
-    policy: on_demand
-    sync_policy: mirror_complete
-    state: present
-  - name: CentOS 8 - Ceph Nautilus (ark)
-    url: "{{ test_dev_pulp_content_url }}/centos/8/storage/x86_64/ceph-nautilus/{{ test_pulp_repo_centos_8_storage_ceph_nautilus_version }}"
-    client_cert: "{{ test_client_cert }}"
-    client_key: "{{ test_client_key }}"
-    policy: on_demand
-    sync_policy: mirror_complete
-    state: present
-  # Note(piotrp): Assuming we'd need this in the future
-  # - name: CentOS 8 - Ceph Octopus (ark)
-  #   url: "{{ test_dev_pulp_content_url }}/centos/8/storage/x86_64/ceph-octopus/{{ test_pulp_repo_centos_8_storage_ceph_octopus_version }}"
-  #   client_cert: "{{ test_client_cert }}"
-  #   client_key: "{{ test_client_key }}"
-  #   policy: on_demand
-  #   sync_policy: mirror_complete
-  #   state: present
-  - name: CentOS 8 - OpsTools - collectd (ark)
-    url: "{{ test_dev_pulp_content_url }}/centos/8/opstools/x86_64/collectd-5/{{ test_pulp_repo_centos_8_opstools_version }}"
-    client_cert: "{{ test_client_cert }}"
-    client_key: "{{ test_client_key }}"
-    policy: on_demand
-    sync_policy: mirror_complete
-    state: present
-
-  # EPEL repositories
-  - name: Extra Packages for Enterprise Linux 8 - x86_64 (ark)
-    url: "{{ test_dev_pulp_content_url }}/epel/8/Everything/x86_64/{{ test_pulp_repo_epel_version }}"
-    client_cert: "{{ test_client_cert }}"
-    client_key: "{{ test_client_key }}"
-    policy: on_demand
-    sync_policy: mirror_complete
-    state: present
-  - name: Extra Packages for Enterprise Linux Modular 8 - x86_64 (ark)
-    url: "{{ test_dev_pulp_content_url }}/epel/8/Modular/x86_64/{{ test_pulp_repo_epel_modular_version }}"
-    client_cert: "{{ test_client_cert }}"
-    client_key: "{{ test_client_key }}"
-    policy: on_demand
-    sync_policy: mirror_complete
-    state: present
-
-  # Third-party repositories
-  - name: Docker CE for CentOS 8 (ark)
-    url: "{{ test_dev_pulp_content_url }}/docker-ce/centos/8/x86_64/stable/{{ test_pulp_repo_docker_version }}"
-    client_cert: "{{ test_client_cert }}"
-    client_key: "{{ test_client_key }}"
-    policy: on_demand
-    sync_policy: mirror_complete
-    state: present
-  # Note(piotrp): With repository size of 39G - for now we'll want this on_demand
-  - name: ELK repository for 7.x packages (ark)
-    url: "{{ test_dev_pulp_content_url }}/elasticsearch/oss-7.x/{{ test_pulp_repo_elasticsearch_logstash_kibana_7_x_version }}"
-    client_cert: "{{ test_client_cert }}"
-    client_key: "{{ test_client_key }}"
-    policy: on_demand
-    sync_policy: mirror_complete
-    state: present
-  # Note(piotrp): With repository size of 16G - for now we'll want this on_demand
-  - name: Grafana (ark)
-    url: "{{ test_dev_pulp_content_url }}/grafana/oss/rpm/{{ test_pulp_repo_grafana_version }}"
-    client_cert: "{{ test_client_cert }}"
-    client_key: "{{ test_client_key }}"
-    policy: on_demand
-    sync_policy: mirror_complete
-    state: present
-  - name: RabbitMQ - Erlang (ark)
-    url: "{{ test_dev_pulp_content_url }}/rabbitmq/erlang/el/8/x86_64/{{ test_pulp_repo_rabbitmq_erlang_version }}"
-    client_cert: "{{ test_client_cert }}"
-    client_key: "{{ test_client_key }}"
-    policy: on_demand
-    sync_policy: mirror_complete
-    state: present
-  - name: RabbitMQ - Server (ark)
-    url: "{{ test_dev_pulp_content_url }}/rabbitmq/rabbitmq-server/el/8/x86_64/{{ test_pulp_repo_rabbitmq_server_version }}"
-    client_cert: "{{ test_client_cert }}"
-    client_key: "{{ test_client_key }}"
-    policy: on_demand
-    sync_policy: mirror_complete
-    state: present
-  - name: TreasureData 4 (ark)
-    url: "{{ test_dev_pulp_content_url }}/treasuredata/4/redhat/8/x86_64/{{ test_pulp_repo_treasuredata_4_version }}"
-    client_cert: "{{ test_client_cert }}"
-    client_key: "{{ test_client_key }}"
-    policy: on_demand
-    sync_policy: mirror_complete
-    state: present
-
+test_pulp_repository_rpm_repos: >-
+  {%- set test_repos = [] -%}
+  {%- for repo in rpm_package_repos -%}
+  {%- if repo.publish | default(true) -%}
+  {%- set test_repo = {"name": repo.name ~ " (ark)", "url": test_dev_pulp_content_url ~ repo.base_path ~ repo.version} -%}
+  {%- set _ = test_repos.append(test_pulp_repository_rpm_repo_common | combine(test_repo)) -%}
+  {%- endif -%}
+  {%- endfor -%}
+  {{ test_repos }}
 
 # Publication format is a subset of distribution.
 test_pulp_publication_rpm: "{{ test_pulp_distribution_rpm }}"
 
-test_pulp_distribution_rpm:
-  # Base CentOS 8 Stream repositories
-  - name: "centos-stream-8-appstream-{{ test_pulp_repo_centos_stream_8_appstream_version }}-ark"
-    repository: CentOS Stream 8 - AppStream (ark)
-    base_path: "centos/8-stream/AppStream/x86_64/os/{{ test_pulp_repo_centos_stream_8_appstream_version }}"
-    state: present
-    short_name: centos_stream_8_appstream
-  - name: "centos-stream-8-baseos-{{ test_pulp_repo_centos_stream_8_baseos_version }}-ark"
-    repository: CentOS Stream 8 - BaseOS (ark)
-    base_path: "centos/8-stream/BaseOS/x86_64/os/{{ test_pulp_repo_centos_stream_8_baseos_version }}"
-    state: present
-    short_name: centos_stream_8_baseos
-  - name: "centos-stream-8-extras-{{ test_pulp_repo_centos_stream_8_extras_version }}-ark"
-    repository: CentOS Stream 8 - Extras (ark)
-    base_path: "centos/8-stream/extras/x86_64/os/{{ test_pulp_repo_centos_stream_8_extras_version }}"
-    state: present
-    short_name: centos_stream_8_extras
+# Common parameters for RPM package distributions.
+test_pulp_distribution_rpm_common:
+  state: present
 
-  # Additional CentOS 8 Stream repositories
-  - name: "centos-stream-8-advancedvirt-{{ test_pulp_repo_centos_stream_8_advanced_virtualization_version }}-ark"
-    repository: CentOS Stream 8 - Advanced Virtualization (ark)
-    base_path: "centos/8-stream/virt/x86_64/advancedvirt-common/{{ test_pulp_repo_centos_stream_8_advanced_virtualization_version }}"
-    state: present
-    short_name: centos_stream_8_advanced_virtualization
-  - name: "centos-stream-8-storage-ceph-pacific-{{ test_pulp_repo_centos_stream_8_storage_ceph_pacific_version }}-ark"
-    repository: CentOS Stream 8 - Ceph Pacific (ark)
-    base_path: "centos/8-stream/storage/x86_64/ceph-pacific/{{ test_pulp_repo_centos_stream_8_storage_ceph_pacific_version }}"
-    state: present
-    short_name: centos_stream_8_storage_ceph_pacific
-  - name: "centos-stream-8-nfv-openvswitch-{{ test_pulp_repo_centos_stream_8_nfv_openvswitch_version }}-ark"
-    repository: CentOS Stream 8 - NFV OpenvSwitch (ark)
-    base_path: "centos/8-stream/nfv/x86_64/openvswitch-2/{{ test_pulp_repo_centos_stream_8_nfv_openvswitch_version }}"
-    state: present
-    short_name: centos_stream_8_nfv_openvswitch
-  - name: "centos-stream-8-openstack-wallaby-{{ test_pulp_repo_centos_stream_8_openstack_wallaby_version }}-ark"
-    repository: CentOS Stream 8 - OpenStack Wallaby (ark)
-    base_path: "centos/8-stream/cloud/x86_64/openstack-wallaby/{{ test_pulp_repo_centos_stream_8_openstack_wallaby_version }}"
-    state: present
-    short_name: centos_stream_8_openstack_wallaby
-  - name: "centos-stream-8-powertools-{{ test_pulp_repo_centos_stream_8_powertools_version }}-ark"
-    repository: CentOS Stream 8 - PowerTools (ark)
-    base_path: "centos/8-stream/PowerTools/x86_64/os/{{ test_pulp_repo_centos_stream_8_powertools_version }}"
-    state: present
-    short_name: centos_stream_8_powertools
-  - name: "centos-8-opstools-{{ test_pulp_repo_centos_8_opstools_version }}-ark"
-    repository: CentOS 8 - OpsTools - collectd (ark)
-    base_path: "centos/8/opstools/x86_64/collectd-5/{{ test_pulp_repo_centos_8_opstools_version }}"
-    state: present
-    short_name: centos_8_opstools
-  - name: "centos-8-storage-ceph-nautilus-{{ test_pulp_repo_centos_8_storage_ceph_nautilus_version }}-ark"
-    repository: CentOS 8 - Ceph Nautilus (ark)
-    base_path: "centos/8/storage/x86_64/ceph-nautilus/{{ test_pulp_repo_centos_8_storage_ceph_nautilus_version }}"
-    state: present
-    short_name: centos_8_storage_ceph_nautilus
-  # Note(piotrp): Assuming we'd need this in the future
-  # - name: "centos-8-storage-ceph-octopus-{{ test_pulp_repo_centos_8_storage_ceph_octopus_version }}-ark"
-  #   repository: CentOS 8 - Ceph Octopus (ark)
-  #   base_path: "centos/8/storage/x86_64/ceph-octopus/{{ test_pulp_repo_centos_8_storage_ceph_octopus_version }}"
-  #   state: present
-  #   short_name: centos_8_storage_ceph_octopus
-
-  # EPEL repositories
-  - name: "extra-packages-for-enterprise-linux-8-x86_64-{{ test_pulp_repo_epel_version }}-ark"
-    repository: Extra Packages for Enterprise Linux 8 - x86_64 (ark)
-    base_path: "epel/8/Everything/x86_64/{{ test_pulp_repo_epel_version }}"
-    state: present
-    short_name: epel
-  - name: "extra-packages-for-enterprise-linux-modular-8-x86_64-{{ test_pulp_repo_epel_modular_version }}-ark"
-    repository: Extra Packages for Enterprise Linux Modular 8 - x86_64 (ark)
-    base_path: "epel/8/Modular/x86_64/{{ test_pulp_repo_epel_modular_version }}"
-    state: present
-    short_name: epel_modular
-
-  # Third-party repositories
-  - name: "docker-ce-for-centos-8-{{ test_pulp_repo_docker_version }}-ark"
-    repository: Docker CE for CentOS 8 (ark)
-    base_path: "docker-ce/centos/8/x86_64/stable/{{ test_pulp_repo_docker_version }}"
-    state: present
-    short_name: docker
-  - name: "elasticsearch-logstash-kibana-7.x-{{ test_pulp_repo_elasticsearch_logstash_kibana_7_x_version }}-ark"
-    repository: ELK repository for 7.x packages (ark)
-    base_path: "elasticsearch/oss-7.x/{{ test_pulp_repo_elasticsearch_logstash_kibana_7_x_version }}"
-    state: present
-    short_name: elasticsearch_logstash_kibana_7_x
-  - name: "grafana-{{ test_pulp_repo_grafana_version }}-ark"
-    repository: Grafana (ark)
-    base_path: "grafana/oss/rpm/{{ test_pulp_repo_grafana_version }}"
-    state: present
-    short_name: grafana
-  - name: "rabbitmq-erlang-{{ test_pulp_repo_rabbitmq_erlang_version }}-ark"
-    repository: RabbitMQ - Erlang (ark)
-    base_path: "rabbitmq/erlang/el/8/x86_64/{{ test_pulp_repo_rabbitmq_erlang_version }}"
-    state: present
-    short_name: rabbitmq_erlang
-  - name: "rabbitmq-server-{{ test_pulp_repo_rabbitmq_server_version }}-ark"
-    repository: RabbitMQ - Server (ark)
-    base_path: "rabbitmq/rabbitmq-server/el/8/x86_64/{{ test_pulp_repo_rabbitmq_server_version }}"
-    state: present
-    short_name: rabbitmq_server
-  - name: "treasuredata-4-{{ test_pulp_repo_treasuredata_4_version }}-ark"
-    repository: TreasureData 4 (ark)
-    base_path: "treasuredata/4/redhat/8/x86_64/{{ test_pulp_repo_treasuredata_4_version }}"
-    state: present
-    short_name: treasuredata_4
+test_pulp_distribution_rpm: >-
+  {%- set test_dists = [] -%}
+  {%- for repo in rpm_package_repos -%}
+  {%- if repo.publish | default(true) -%}
+  {%- set name = repo.distribution_name ~ repo.version ~ "-ark" -%}
+  {%- set repo_name = repo.name ~ " (ark)" -%}
+  {%- set base_path = repo.base_path ~ repo.version -%}
+  {%- set test_dist = {"name": name, "repository": repo_name, "base_path": base_path, "short_name": repo.short_name} -%}
+  {%- set _ = test_dists.append(test_pulp_distribution_rpm_common | combine(test_dist)) -%}
+  {%- endif -%}
+  {%- endfor -%}
+  {{ test_dists }}
 
 # Whether to skip existing RPM distributions. If true, new distributions will
 # not be created for a publication if any distributions exist for the same


### PR DESCRIPTION
Use a single master list of repositories, and generate other lists from there.

Vastly reduces duplication.

This was tested by running the following playbook before and after, and
comparing the generated hostvars dumps.

```
  - hosts: localhost
    gather_facts: no
    vars:
    tasks:
      - set_fact:
          ansible_date_time:
            iso8601_basic_short: 2022-01-13
          dev_pulp_repository_container_promotion_tag: foo

      - copy:
          content: "{{ hostvars.localhost | to_nice_yaml }}"
          dest: ../hostvars
```

There are some minor changes:

* CentOS Linux Ceph Octopus repository is now synced (but still not
  published)
* Missing sync_policy added to ELK and Grafana repos in dev