### PR TITLE
Fix package repository promotion

### DIFF
--- a/ansible/dev-pulp-repo-promote.yml
+++ b/ansible/dev-pulp-repo-promote.yml
@@ -14,11 +14,9 @@
     - name: Assert that versions variable is populated
       assert:
         that:
-          - missing_repos | length == 0
+          - dev_pulp_distribution_rpm_promote_versions | length > 0
         msg: >-
-          Some expected repositories not present in distribution promotion versions: {{ missing_repos | join(',') }}
-      vars:
-        missing_repos: "{{ dev_pulp_distribution_rpm_promote | map(attribute='short_name') | list | difference(dev_pulp_distribution_rpm_promote_versions) | list }}"
+          Distribution promotion version variable 'dev_pulp_distribution_rpm_promote_versions' is empty
 
     # We want to update existing distributions here, so omit the 'publication'
     # parameter.
@@ -31,4 +29,4 @@
         base_path: "{{ item.base_path }}"
         content_guard: "{{ item.content_guard }}"
         state: "{{ item.state }}"
-      loop: "{{ dev_pulp_distribution_rpm_promote }}"
+      loop: "{{ dev_pulp_distribution_rpm_promote | selectattr('short_name', 'in', dev_pulp_distribution_rpm_promote_versions.keys()) | list }}"

--- a/ansible/dev-pulp-repo-version-query-kayobe.yml
+++ b/ansible/dev-pulp-repo-version-query-kayobe.yml
@@ -56,8 +56,6 @@
     - name: Assert that versions variable is populated
       assert:
         that:
-          - missing_repos | length == 0
+          - dev_pulp_distribution_rpm_promote_versions | length > 0
         msg: >-
-          Some expected repositories not present in Kayobe Pulp repository versions: {{ missing_repos | join(',') }}
-      vars:
-        missing_repos: "{{ dev_pulp_distribution_rpm_promote | map(attribute='short_name') | list | difference(dev_pulp_distribution_rpm_promote_versions) | list }}"
+          Distribution promotion version variable 'dev_pulp_distribution_rpm_promote_versions' is empty


### PR DESCRIPTION
Package repository promotion was broken by the addition of Rocky Linux
repositories, since they are not included in the kayobe configuration
currently.

This change fixes the issue by only promoting repositories that are
present in the kayobe configuration.