### PR TITLE
fix: add missing labels prior to opening a PR

### DIFF
--- a/ansible/roles/source-repo-sync/tasks/add_community_files.yml
+++ b/ansible/roles/source-repo-sync/tasks/add_community_files.yml
@@ -51,6 +51,14 @@
     chdir: '{{ staging_path }}/{{ repository_manifest.name }}'
   when: community_copy.changed | bool
 
+- name: Ensure required labels exists on remote
+  ansible.builtin.include_tasks: 'tasks/add_label.yml'
+  with_items:
+    - stackhpc-ci
+    - community-files
+  loop_control:
+    loop_var: label_name
+
 - name: Open pull request # noqa command-instead-of-shell no-handler
   ansible.builtin.shell:
     cmd: 'gh pr create --fill --base {{ community_manifest.prefix | default("") }}{{ community_manifest.branch }} --label stackhpc-ci --label community-files'

--- a/ansible/roles/source-repo-sync/tasks/add_label.yml
+++ b/ansible/roles/source-repo-sync/tasks/add_label.yml
@@ -1,0 +1,13 @@
+---
+- name: Check if required label exists # noqa command-instead-of-shell
+  ansible.builtin.shell:
+    cmd: gh label list --json name --jq 'any(.name == "{{ label_name }}")'
+    chdir: '{{ staging_path }}/{{ repository_manifest.name }}'
+  changed_when: false
+  register: label_exists
+
+- name: Add missing label to repository # noqa command-instead-of-shell
+  ansible.builtin.shell:
+    cmd: gh label create {{ label_name | quote }}
+    chdir: '{{ staging_path }}/{{ repository_manifest.name }}'
+  when: not label_exists.stdout | bool

--- a/ansible/roles/source-repo-sync/tasks/add_workflows.yml
+++ b/ansible/roles/source-repo-sync/tasks/add_workflows.yml
@@ -54,6 +54,14 @@
     chdir: '{{ staging_path }}/{{ repository_manifest.name }}'
   when: workflow_copy.changed | bool
 
+- name: Ensure required labels exists on remote
+  ansible.builtin.include_tasks: 'tasks/add_label.yml'
+  with_items:
+    - stackhpc-ci
+    - workflows
+  loop_control:
+    loop_var: label_name
+
 - name: Open pull request # noqa command-instead-of-shell no-handler
   ansible.builtin.shell:
     cmd: 'gh pr create --fill --base {{ workflow_manifest.prefix  |  default("") }}{{ workflow_manifest.branch }} --label stackhpc-ci --label workflows'

--- a/ansible/roles/source-repo-sync/tasks/add_workflows.yml
+++ b/ansible/roles/source-repo-sync/tasks/add_workflows.yml
@@ -56,7 +56,7 @@
 
 - name: Open pull request # noqa command-instead-of-shell no-handler
   ansible.builtin.shell:
-    cmd: 'gh pr create --fill --base {{ workflow_manifest.prefix  |  default("") }}{{ workflow_manifest.branch }} --label stackhpci --label workflows'
+    cmd: 'gh pr create --fill --base {{ workflow_manifest.prefix  |  default("") }}{{ workflow_manifest.branch }} --label stackhpc-ci --label workflows'
     chdir: '{{ staging_path }}/{{ repository_manifest.name }}'
   when: workflow_copy.changed | bool
 


### PR DESCRIPTION
Using the Github API we can ensure that labels exist on the target repository prior to creating a PR with those labels.