### PR TITLE
fix: remove newlines from API requests

### DIFF
--- a/ansible/roles/source-repo-sync/tasks/add_community_files.yml
+++ b/ansible/roles/source-repo-sync/tasks/add_community_files.yml
@@ -1,26 +1,26 @@
 ---
 - name: Check if working branch already exists on the remote
-  ansible.builtin.shell:
+  ansible.builtin.command:
     cmd: |
-      gh api \
-      -H "Accept: application/vnd.github.v3+json" \
+      gh api
+      -H "Accept: application/vnd.github.v3+json"
       /repos/{{ owner }}/{{ repository_manifest.name }}/git/ref/heads/{{ community_manifest.branch }}-community-files
   changed_when: false
   failed_when: false
   register: branch_exists
 
 - name: Delete working branch from the remote
-  ansible.builtin.shell:
+  ansible.builtin.command:
     cmd: |
-      gh api \
-      --method DELETE \
-      -H "Accept: application/vnd.github.v3+json" \
+      gh api
+      --method DELETE
+      -H "Accept: application/vnd.github.v3+json"
       /repos/{{ owner }}/{{ repository_manifest.name }}/git/refs/heads/{{ community_manifest.branch }}-community-files
   when: branch_exists.rc == 0
 
 - name: Create working branch # noqa command-instead-of-module
   ansible.builtin.shell:
-    cmd: |
+    cmd: >
       git checkout -b {{ community_manifest.branch }}-community-files \
         origin/{{ community_manifest.prefix | default("") }}{{ community_manifest.branch }}
     chdir: '{{ staging_path }}/{{ repository_manifest.name }}'

--- a/ansible/roles/source-repo-sync/tasks/add_community_files.yml
+++ b/ansible/roles/source-repo-sync/tasks/add_community_files.yml
@@ -1,20 +1,20 @@
 ---
 - name: Check if working branch already exists on the remote
-  ansible.builtin.command:
+  ansible.builtin.shell:
     cmd: |
-      gh api
-      -H "Accept: application/vnd.github.v3+json"
+      gh api \
+      -H "Accept: application/vnd.github.v3+json" \
       /repos/{{ owner }}/{{ repository_manifest.name }}/git/ref/heads/{{ community_manifest.branch }}-community-files
   changed_when: false
   failed_when: false
   register: branch_exists
 
 - name: Delete working branch from the remote
-  ansible.builtin.command:
+  ansible.builtin.shell:
     cmd: |
-      gh api
-      --method DELETE
-      -H "Accept: application/vnd.github.v3+json"
+      gh api \
+      --method DELETE \
+      -H "Accept: application/vnd.github.v3+json" \
       /repos/{{ owner }}/{{ repository_manifest.name }}/git/refs/heads/{{ community_manifest.branch }}-community-files
   when: branch_exists.rc == 0
 

--- a/ansible/roles/source-repo-sync/tasks/add_workflows.yml
+++ b/ansible/roles/source-repo-sync/tasks/add_workflows.yml
@@ -1,20 +1,20 @@
 ---
 - name: Check if working branch already exists on the remote
-  ansible.builtin.command:
+  ansible.builtin.shell:
     cmd: |
-      gh api
-      -H "Accept: application/vnd.github.v3+json"
+      gh api \
+      -H "Accept: application/vnd.github.v3+json" \
       /repos/{{ owner }}/{{ repository_manifest.name }}/git/ref/heads/{{ workflow_manifest.branch }}-workflows
   changed_when: false
   failed_when: false
   register: branch_exists
 
 - name: Delete working branch from the remote
-  ansible.builtin.command:
+  ansible.builtin.shell:
     cmd: |
-      gh api
-      --method DELETE
-      -H "Accept: application/vnd.github.v3+json"
+      gh api \
+      --method DELETE \
+      -H "Accept: application/vnd.github.v3+json" \
       /repos/{{ owner }}/{{ repository_manifest.name }}/git/refs/heads/{{ workflow_manifest.branch }}-workflows
   when: branch_exists.rc == 0
 

--- a/ansible/roles/source-repo-sync/tasks/add_workflows.yml
+++ b/ansible/roles/source-repo-sync/tasks/add_workflows.yml
@@ -1,9 +1,9 @@
 ---
 - name: Check if working branch already exists on the remote
   ansible.builtin.command:
-    cmd: >
-      gh api \
-      -H "Accept: application/vnd.github.v3+json" \
+    cmd: |
+      gh api
+      -H "Accept: application/vnd.github.v3+json"
       /repos/{{ owner }}/{{ repository_manifest.name }}/git/ref/heads/{{ workflow_manifest.branch }}-workflows
   changed_when: false
   failed_when: false
@@ -11,10 +11,10 @@
 
 - name: Delete working branch from the remote
   ansible.builtin.command:
-    cmd: >
-      gh api \
-      --method DELETE \
-      -H "Accept: application/vnd.github.v3+json" \
+    cmd: |
+      gh api
+      --method DELETE
+      -H "Accept: application/vnd.github.v3+json"
       /repos/{{ owner }}/{{ repository_manifest.name }}/git/refs/heads/{{ workflow_manifest.branch }}-workflows
   when: branch_exists.rc == 0
 


### PR DESCRIPTION
Some of the API requests failed due to `ansible.builtin.command` inserting newlines. Not sure why only now this error has appeared. Fixed by remove `\` from commands and using `|` for multiline block.