### PR TITLE
CI: Use public ubuntu-latest runner where possible

### DIFF
--- a/.github/workflows/container-promote.yml
+++ b/.github/workflows/container-promote.yml
@@ -13,7 +13,7 @@ env:
 jobs:
   container-promote:
     name: Promote container repositories
-    runs-on: [self-hosted, stackhpc-release-train]
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
 

--- a/.github/workflows/package-promote.yml
+++ b/.github/workflows/package-promote.yml
@@ -14,7 +14,7 @@ env:
 jobs:
   package-promote:
     name: Promote package repositories
-    runs-on: [self-hosted, stackhpc-release-train]
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
 

--- a/.github/workflows/package-update-kayobe.yml
+++ b/.github/workflows/package-update-kayobe.yml
@@ -14,7 +14,7 @@ env:
 jobs:
   package-update-kayobe:
     name: Update Kayobe package repository versions
-    runs-on: [self-hosted, stackhpc-release-train]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
We don't need to use the self-hosted runner if we're not accessing Test Pulp.