### PR TITLE
Add CentOS Stream 8 Ceph Nautilus and OpsTools repos

### DIFF
--- a/ansible/inventory/group_vars/all/package-repos
+++ b/ansible/inventory/group_vars/all/package-repos
@@ -34,6 +34,11 @@ rpm_package_repos:
     base_path: centos/8-stream/virt/x86_64/advancedvirt-common/
     short_name: centos_stream_8_advanced_virtualization
     distribution_name: centos-stream-8-advancedvirt-
+  - name: CentOS Stream 8 - Ceph Nautilus
+    url: http://mirrorlist.centos.org/?release=8-stream&arch=x86_64&repo=storage-ceph-nautilus
+    base_path: centos/8-stream/storage/x86_64/ceph-nautilus/
+    short_name: centos_stream_8_storage_ceph_nautilus
+    distribution_name: centos-stream-8-storage-ceph-nautilus-
   - name: CentOS Stream 8 - Ceph Pacific
     url: http://mirrorlist.centos.org/?release=8-stream&arch=x86_64&repo=storage-ceph-pacific
     base_path: centos/8-stream/storage/x86_64/ceph-pacific/

--- a/ansible/inventory/group_vars/all/package-repos
+++ b/ansible/inventory/group_vars/all/package-repos
@@ -54,6 +54,11 @@ rpm_package_repos:
     base_path: centos/8-stream/cloud/x86_64/openstack-wallaby/
     short_name: centos_stream_8_openstack_wallaby
     distribution_name: centos-stream-8-openstack-wallaby-
+  - name: CentOS Stream 8 - OpsTools - collectd
+    url: http://mirrorlist.centos.org/?release=8-stream&arch=x86_64&repo=opstools-collectd-5
+    base_path: centos/8-stream/opstools/x86_64/collectd-5/
+    short_name: centos_stream_8_opstools
+    distribution_name: centos-stream-8-opstools-
   - name: CentOS Stream 8 - PowerTools
     url: http://mirrorlist.centos.org/?release=8-stream&arch=x86_64&repo=PowerTools&infra=genclo
     base_path: centos/8-stream/PowerTools/x86_64/os/


### PR DESCRIPTION
Currently we only have the CentOS Linux 8 Ceph Nautilus and OpsTools repos, which
stopped providing updates in January.