### PR TITLE
source-repo-sync: define codeowners via variables

### DIFF
--- a/ansible/inventory/group_vars/all/source-repositories
+++ b/ansible/inventory/group_vars/all/source-repositories
@@ -17,9 +17,15 @@ ansible_workflows:
     - publish_collection
   role:
     - publish_role
+kayobe_codeowners: |
+  * @stackhpc/kayobe
+ansible_codeowners: |
+  * @stackhpc/ansible
 source_repositories:
   kolla:
     workflows: '{{ openstack_workflows }}'
+    codeowners: '{{ kayobe_codeowners }}'
   ansible-collection-pulp:
     repository_type: 'ansible'
     workflows: '{{ ansible_workflows.collection }}'
+    codeowners: '{{ ansible_codeowners }}'

--- a/ansible/roles/source-repo-sync/files/codeowners/ansible-collection-pulp
+++ b/ansible/roles/source-repo-sync/files/codeowners/ansible-collection-pulp
@@ -1,1 +1,0 @@
-* @stackhpc/ansible

--- a/ansible/roles/source-repo-sync/files/codeowners/kolla
+++ b/ansible/roles/source-repo-sync/files/codeowners/kolla
@@ -1,1 +1,0 @@
-* @stackhpc/kayobe

--- a/ansible/roles/source-repo-sync/tasks/add_community_files.yml
+++ b/ansible/roles/source-repo-sync/tasks/add_community_files.yml
@@ -34,10 +34,11 @@
 
 - name: Copy community files
   ansible.builtin.copy:
-    src: 'files/codeowners/{{ repository_manifest.name }}'
+    content: '{{ repository_manifest.codeowners }}'
     dest: '{{ staging_path }}/{{ repository_manifest.name }}/.github/CODEOWNERS'
     mode: 0755
   register: community_copy
+  when: repository_manifest.codeowners | default('') | length > 0
 
 - name: Commit changes # noqa command-instead-of-module no-handler
   ansible.builtin.shell:

--- a/ansible/roles/source-repo-sync/tasks/configure_repository.yml
+++ b/ansible/roles/source-repo-sync/tasks/configure_repository.yml
@@ -45,7 +45,6 @@
     community_manifest:
       {
         branch: '{{ default_branch_name.stdout }}',
-        copy_codeowners: '{{ repository_manifest.copy_codeowners }}',
       }
   when: repository_manifest.copy_codeowners | bool
 

--- a/ansible/roles/source-repo-sync/tasks/main.yml
+++ b/ansible/roles/source-repo-sync/tasks/main.yml
@@ -21,6 +21,7 @@
             elsewhere: '{{ openstack_workflows.elsewhere |
               difference(item.value.workflows.ignored_workflows.elsewhere | default([])) |
               union(item.value.workflows.additional_workflows.elsewhere | default([])) }}' },
+        codeowners: '{{ item.value.codeowners | default('') }}',
         copy_workflows: '{{ item.value.copy_workflows | default(true) }}',
         copy_codeowners: '{{ item.value.copy_codeowners | default(true) }}',
       }
@@ -34,6 +35,7 @@
       {
         name: '{{ item.key }}',
         workflows: { default_branch_only: '{{ item.value.workflows }}' },
+        codeowners: '{{ item.value.codeowners | default("") }}',
         copy_workflows: '{{ item.value.copy_workflows | default(true) }}',
         copy_codeowners: '{{ item.value.copy_codeowners | default(true) }}',
       }


### PR DESCRIPTION
This keeps the role generic, and reduces duplication of content.