### PR TITLE
Inherit secrets fix

### DIFF
--- a/ansible/inventory/group_vars/all/source-repositories
+++ b/ansible/inventory/group_vars/all/source-repositories
@@ -14,9 +14,9 @@ openstack_workflows:
     - tag-and-release
 ansible_workflows:
   collection:
-    - publish_collection
+    - publish-collection
   role:
-    - publish_role
+    - publish-role
 community_files:
   codeowners:
     kayobe_codeowners: |

--- a/ansible/roles/source-repo-sync/tasks/add_workflows.yml
+++ b/ansible/roles/source-repo-sync/tasks/add_workflows.yml
@@ -62,9 +62,14 @@
 
     - name: Remove publish workflow
       ansible.builtin.file:
-        path: '{{ staging_path }}/{{ repository_manifest.name }}/.github/workflows/publish.yml'
+        path: '{{ staging_path }}/{{ repository_manifest.name }}/.github/workflows/{{ unwanted_workflow }}.yml'
         state: absent
       register: publish_rm
+      with_items:
+        - publish_role
+        - publish_collection
+      loop_control:
+        loop_var: unwanted_workflow
 
     - block:
         - name: Commit changes # noqa command-instead-of-module no-handler

--- a/ansible/roles/source-repo-sync/templates/publish-collection.jinja
+++ b/ansible/roles/source-repo-sync/templates/publish-collection.jinja
@@ -8,4 +8,5 @@ name: Publish Ansible Collection
 jobs:
   publish_collection:
     uses: stackhpc/.github/.github/workflows/publish-collection.yml@main
-    secrets: inherit
+    secrets:
+      GALAXY_API_KEY: ${{ secrets.GALAXY_API_KEY }}

--- a/ansible/roles/source-repo-sync/templates/publish-collection.jinja
+++ b/ansible/roles/source-repo-sync/templates/publish-collection.jinja
@@ -7,4 +7,5 @@ name: Publish Ansible Collection
   workflow_dispatch:
 jobs:
   publish_collection:
-    uses: stackhpc/.github/.github/workflows/publish_collection.yml@main
+    uses: stackhpc/.github/.github/workflows/publish-collection.yml@main
+    secrets: inherit

--- a/ansible/roles/source-repo-sync/templates/publish-role.jinja
+++ b/ansible/roles/source-repo-sync/templates/publish-role.jinja
@@ -7,4 +7,5 @@ name: Publish Ansible Role
   workflow_dispatch:
 jobs:
   publish_role:
-    uses: stackhpc/.github/.github/workflows/publish_role.yml@main
+    uses: stackhpc/.github/.github/workflows/publish-role.yml@main
+    secrets: inherit

--- a/ansible/roles/source-repo-sync/templates/publish-role.jinja
+++ b/ansible/roles/source-repo-sync/templates/publish-role.jinja
@@ -8,4 +8,5 @@ name: Publish Ansible Role
 jobs:
   publish_role:
     uses: stackhpc/.github/.github/workflows/publish-role.yml@main
-    secrets: inherit
+    secrets:
+      GALAXY_API_KEY: ${{ secrets.GALAXY_API_KEY }}


### PR DESCRIPTION
A number of changes have been made to the ansible workflows.

1. Correct the mistake regarding hyphens and underscores. This should only be merged if the corresponding PR in the .github repository is also merged.

2. Automate the process of removing the old ansible workflows to prevent collisions.

3. Update the templates to use the hyphen workflow and more importantly pass the `GALAXY_API_SECRET` explicitly.