### PR TITLE
Add `codeowners` to all repositories defined within `source_repositories`

### DIFF
--- a/ansible/inventory/group_vars/all/source-repositories
+++ b/ansible/inventory/group_vars/all/source-repositories
@@ -55,7 +55,7 @@ source_repositories:
       - xena
     community_files:
       - codeowners:
-          content: '{{ community_files.codeowners.openstack }}'
+          content: '{{ community_files.codeowners.kayobe }}'
           dest: '.github/CODEOWNERS'
   barbican:
     ignored_releases:

--- a/ansible/inventory/group_vars/all/source-repositories
+++ b/ansible/inventory/group_vars/all/source-repositories
@@ -19,6 +19,8 @@ ansible_workflows:
     - publish-role
 community_files:
   codeowners:
+    ansible: |
+      * @stackhpc/ansible
     azimuth: |
       * @stackhpc/azimuth
     batch: |

--- a/ansible/inventory/group_vars/all/source-repositories
+++ b/ansible/inventory/group_vars/all/source-repositories
@@ -19,14 +19,14 @@ ansible_workflows:
     - publish-role
 community_files:
   codeowners:
-    kayobe_codeowners: |
-      * @stackhpc/kayobe
-    openstack_codeowners: |
-      * @stackhpc/openstack
     azimuth_codeowners: |
       * @stackhpc/azimuth
     batch_codeowners: |
       * @stackhpc/batch
+    kayobe_codeowners: |
+      * @stackhpc/kayobe
+    openstack_codeowners: |
+      * @stackhpc/openstack
     release_train_codeowners: |
       * @stackhpc/release-train
     sms_lab_codeowners: |

--- a/ansible/inventory/group_vars/all/source-repositories
+++ b/ansible/inventory/group_vars/all/source-repositories
@@ -19,162 +19,354 @@ ansible_workflows:
     - publish-role
 community_files:
   codeowners:
-    azimuth_codeowners: |
+    azimuth: |
       * @stackhpc/azimuth
-    batch_codeowners: |
+    batch: |
       * @stackhpc/batch
-    kayobe_codeowners: |
+    kayobe: |
       * @stackhpc/kayobe
-    openstack_codeowners: |
+    openstack: |
       * @stackhpc/openstack
-    release_train_codeowners: |
+    release_train: |
       * @stackhpc/release-train
-    sms_lab_codeowners: |
+    sms_lab: |
       * @stackhpc/sms-lab
 source_repositories:
   kolla:
     community_files:
       - codeowners:
-          content: '{{ community_files.codeowners.kayobe_codeowners }}'
+          content: '{{ community_files.codeowners.kayobe }}'
           dest: '.github/CODEOWNERS'
   kayobe:
     community_files:
       - codeowners:
-          content: '{{ community_files.codeowners.kayobe_codeowners }}'
+          content: '{{ community_files.codeowners.kayobe }}'
           dest: '.github/CODEOWNERS'
   kolla-ansible:
+    community_files:
+      - codeowners:
+          content: '{{ community_files.codeowners.kayobe }}'
+          dest: '.github/CODEOWNERS'
   bifrost:
     ignored_releases:
       - victoria
       - xena
+    community_files:
+      - codeowners:
+          content: '{{ community_files.codeowners.openstack }}'
+          dest: '.github/CODEOWNERS'
   barbican:
     ignored_releases:
       - victoria
       - xena
+    community_files:
+      - codeowners:
+          content: '{{ community_files.codeowners.openstack }}'
+          dest: '.github/CODEOWNERS'
   cloudkitty:
+    community_files:
+      - codeowners:
+          content: '{{ community_files.codeowners.openstack }}'
+          dest: '.github/CODEOWNERS'
   cloudkitty-dashboard:
+    community_files:
+      - codeowners:
+          content: '{{ community_files.codeowners.openstack }}'
+          dest: '.github/CODEOWNERS'
   ironic-python-agent:
+    community_files:
+      - codeowners:
+          content: '{{ community_files.codeowners.openstack }}'
+          dest: '.github/CODEOWNERS'
   magnum:
     ignored_releases:
       - victoria
+    community_files:
+      - codeowners:
+          content: '{{ community_files.codeowners.openstack }}'
+          dest: '.github/CODEOWNERS'
   networking-generic-switch:
+    community_files:
+      - codeowners:
+          content: '{{ community_files.codeowners.openstack }}'
+          dest: '.github/CODEOWNERS'
   stackhpc-inspector-plugins:
     repository_type: 'branchless'
     workflows: '{{ openstack_workflows.elsewhere }}'
+    community_files:
+      - codeowners:
+          content: '{{ community_files.codeowners.ansible }}'
+          dest: '.github/CODEOWNERS'
   ansible-role-os-host-aggregates:
     repository_type: 'ansible'
     workflows: '{{ ansible_workflows.role }}'
+    community_files:
+      - codeowners:
+          content: '{{ community_files.codeowners.ansible }}'
+          dest: '.github/CODEOWNERS'
   ansible-role-os-networks:
     repository_type: 'ansible'
     workflows: '{{ ansible_workflows.role }}'
+    community_files:
+      - codeowners:
+          content: '{{ community_files.codeowners.ansible }}'
+          dest: '.github/CODEOWNERS'
   ansible-role-os-projects:
     repository_type: 'ansible'
     workflows: '{{ ansible_workflows.role }}'
+    community_files:
+      - codeowners:
+          content: '{{ community_files.codeowners.ansible }}'
+          dest: '.github/CODEOWNERS'
   ansible-role-libvirt-host:
     repository_type: 'ansible'
     workflows: '{{ ansible_workflows.role }}'
+    community_files:
+      - codeowners:
+          content: '{{ community_files.codeowners.ansible }}'
+          dest: '.github/CODEOWNERS'
   ansible-role-openhpc:
     repository_type: 'ansible'
     workflows: '{{ ansible_workflows.role }}'
+    community_files:
+      - codeowners:
+          content: '{{ community_files.codeowners.ansible }}'
+          dest: '.github/CODEOWNERS'
   ansible-role-libvirt-vm:
     repository_type: 'ansible'
     workflows: '{{ ansible_workflows.role }}'
+    community_files:
+      - codeowners:
+          content: '{{ community_files.codeowners.ansible }}'
+          dest: '.github/CODEOWNERS'
   ansible-role-os-images:
     repository_type: 'ansible'
     workflows: '{{ ansible_workflows.role }}'
+    community_files:
+      - codeowners:
+          content: '{{ community_files.codeowners.ansible }}'
+          dest: '.github/CODEOWNERS'
   drac:
     repository_type: 'ansible'
     workflows: '{{ ansible_workflows.role }}'
+    community_files:
+      - codeowners:
+          content: '{{ community_files.codeowners.ansible }}'
+          dest: '.github/CODEOWNERS'
   ansible-role-luks:
     repository_type: 'ansible'
     workflows: '{{ ansible_workflows.role }}'
+    community_files:
+      - codeowners:
+          content: '{{ community_files.codeowners.ansible }}'
+          dest: '.github/CODEOWNERS'
   ansible-role-os-volumes:
     repository_type: 'ansible'
     workflows: '{{ ansible_workflows.role }}'
+    community_files:
+      - codeowners:
+          content: '{{ community_files.codeowners.ansible }}'
+          dest: '.github/CODEOWNERS'
   ansible-role-grubcmdline:
     repository_type: 'ansible'
     workflows: '{{ ansible_workflows.role }}'
+    community_files:
+      - codeowners:
+          content: '{{ community_files.codeowners.ansible }}'
+          dest: '.github/CODEOWNERS'
   ansible-role-os-flavors:
     repository_type: 'ansible'
     workflows: '{{ ansible_workflows.role }}'
+    community_files:
+      - codeowners:
+          content: '{{ community_files.codeowners.ansible }}'
+          dest: '.github/CODEOWNERS'
   ansible-role-os-openstacksdk:
     repository_type: 'ansible'
     workflows: '{{ ansible_workflows.role }}'
+    community_files:
+      - codeowners:
+          content: '{{ community_files.codeowners.ansible }}'
+          dest: '.github/CODEOWNERS'
   ansible-role-sriov:
     repository_type: 'ansible'
     workflows: '{{ ansible_workflows.role }}'
+    community_files:
+      - codeowners:
+          content: '{{ community_files.codeowners.ansible }}'
+          dest: '.github/CODEOWNERS'
   ansible-role-os-openstackclient:
     repository_type: 'ansible'
     workflows: '{{ ansible_workflows.role }}'
+    community_files:
+      - codeowners:
+          content: '{{ community_files.codeowners.ansible }}'
+          dest: '.github/CODEOWNERS'
   ansible-timezone:
     repository_type: 'ansible'
     workflows: '{{ ansible_workflows.role }}'
+    community_files:
+      - codeowners:
+          content: '{{ community_files.codeowners.ansible }}'
+          dest: '.github/CODEOWNERS'
   ansible-role-os-shade:
     repository_type: 'ansible'
     workflows: '{{ ansible_workflows.role }}'
+    community_files:
+      - codeowners:
+          content: '{{ community_files.codeowners.ansible }}'
+          dest: '.github/CODEOWNERS'
   ansible-role-grafana-conf:
     repository_type: 'ansible'
     workflows: '{{ ansible_workflows.role }}'
+    community_files:
+      - codeowners:
+          content: '{{ community_files.codeowners.ansible }}'
+          dest: '.github/CODEOWNERS'
   ansible-role-systemd-networkd:
     repository_type: 'ansible'
     workflows: '{{ ansible_workflows.role }}'
+    community_files:
+      - codeowners:
+          content: '{{ community_files.codeowners.ansible }}'
+          dest: '.github/CODEOWNERS'
   monasca-default-alarms:
     repository_type: 'ansible'
     workflows: '{{ ansible_workflows.role }}'
+    community_files:
+      - codeowners:
+          content: '{{ community_files.codeowners.ansible }}'
+          dest: '.github/CODEOWNERS'
   stackhpc.ssm:
     repository_type: 'ansible'
     workflows: '{{ ansible_workflows.role }}'
+    community_files:
+      - codeowners:
+          content: '{{ community_files.codeowners.ansible }}'
+          dest: '.github/CODEOWNERS'
   ansible-role-monasca-rsyslog:
     repository_type: 'ansible'
     workflows: '{{ ansible_workflows.role }}'
+    community_files:
+      - codeowners:
+          content: '{{ community_files.codeowners.ansible }}'
+          dest: '.github/CODEOWNERS'
   ansible-role-os-container-clusters:
     repository_type: 'ansible'
     workflows: '{{ ansible_workflows.role }}'
+    community_files:
+      - codeowners:
+          content: '{{ community_files.codeowners.ansible }}'
+          dest: '.github/CODEOWNERS'
   ansible-role-cluster-infra:
     repository_type: 'ansible'
     workflows: '{{ ansible_workflows.role }}'
+    community_files:
+      - codeowners:
+          content: '{{ community_files.codeowners.ansible }}'
+          dest: '.github/CODEOWNERS'
   ansible-role-os-ironic-state:
     repository_type: 'ansible'
     workflows: '{{ ansible_workflows.role }}'
+    community_files:
+      - codeowners:
+          content: '{{ community_files.codeowners.ansible }}'
+          dest: '.github/CODEOWNERS'
   ansible-role-openvpn:
     repository_type: 'ansible'
     workflows: '{{ ansible_workflows.role }}'
+    community_files:
+      - codeowners:
+          content: '{{ community_files.codeowners.ansible }}'
+          dest: '.github/CODEOWNERS'
   stackhpc.ipmi-exporter:
     repository_type: 'ansible'
     workflows: '{{ ansible_workflows.role }}'
+    community_files:
+      - codeowners:
+          content: '{{ community_files.codeowners.ansible }}'
+          dest: '.github/CODEOWNERS'
   ansible-role-mlnx-ufm:
     repository_type: 'ansible'
     workflows: '{{ ansible_workflows.role }}'
+    community_files:
+      - codeowners:
+          content: '{{ community_files.codeowners.ansible }}'
+          dest: '.github/CODEOWNERS'
   ansible-role-rundeck:
     repository_type: 'ansible'
     workflows: '{{ ansible_workflows.role }}'
+    community_files:
+      - codeowners:
+          content: '{{ community_files.codeowners.ansible }}'
+          dest: '.github/CODEOWNERS'
   ansible-role-dell-powerconnect-switch:
     repository_type: 'ansible'
     workflows: '{{ ansible_workflows.role }}'
+    community_files:
+      - codeowners:
+          content: '{{ community_files.codeowners.ansible }}'
+          dest: '.github/CODEOWNERS'
   drac-facts:
     repository_type: 'ansible'
     workflows: '{{ ansible_workflows.role }}'
+    community_files:
+      - codeowners:
+          content: '{{ community_files.codeowners.ansible }}'
+          dest: '.github/CODEOWNERS'
   ansible-role-gluster-cluster:
     repository_type: 'ansible'
     workflows: '{{ ansible_workflows.role }}'
+    community_files:
+      - codeowners:
+          content: '{{ community_files.codeowners.ansible }}'
+          dest: '.github/CODEOWNERS'
   ansible-role-mellanox-switch:
     repository_type: 'ansible'
     workflows: '{{ ansible_workflows.role }}'
+    community_files:
+      - codeowners:
+          content: '{{ community_files.codeowners.ansible }}'
+          dest: '.github/CODEOWNERS'
   ansible-role-os-config:
     repository_type: 'ansible'
     workflows: '{{ ansible_workflows.role }}'
+    community_files:
+      - codeowners:
+          content: '{{ community_files.codeowners.ansible }}'
+          dest: '.github/CODEOWNERS'
   ansible-role-mlnx-neo:
     repository_type: 'ansible'
     workflows: '{{ ansible_workflows.role }}'
+    community_files:
+      - codeowners:
+          content: '{{ community_files.codeowners.ansible }}'
+          dest: '.github/CODEOWNERS'
   ansible-collection-cephadm:
     repository_type: 'ansible'
     workflows: '{{ ansible_workflows.collection }}'
+    community_files:
+      - codeowners:
+          content: '{{ community_files.codeowners.ansible }}'
+          dest: '.github/CODEOWNERS'
   ansible-collection-pulp:
     repository_type: 'ansible'
     workflows: '{{ ansible_workflows.collection }}'
+    community_files:
+      - codeowners:
+          content: '{{ community_files.codeowners.ansible }}'
+          dest: '.github/CODEOWNERS'
   ansible-collection-hashicorp:
     repository_type: 'ansible'
     workflows: '{{ ansible_workflows.collection }}'
+    community_files:
+      - codeowners:
+          content: '{{ community_files.codeowners.ansible }}'
+          dest: '.github/CODEOWNERS'
   ansible-collection-openstack-ops:
     repository_type: 'ansible'
     workflows: '{{ ansible_workflows.collection }}'
+    community_files:
+      - codeowners:
+          content: '{{ community_files.codeowners.ansible }}'
+          dest: '.github/CODEOWNERS'

--- a/ansible/inventory/group_vars/all/source-repositories
+++ b/ansible/inventory/group_vars/all/source-repositories
@@ -21,8 +21,16 @@ community_files:
   codeowners:
     kayobe_codeowners: |
       * @stackhpc/kayobe
-    ansible_codeowners: |
-      * @stackhpc/ansible
+    openstack_codeowners: |
+      * @stackhpc/openstack
+    azimuth_codeowners: |
+      * @stackhpc/azimuth
+    batch_codeowners: |
+      * @stackhpc/batch
+    release_train_codeowners: |
+      * @stackhpc/release-train
+    sms_lab_codeowners: |
+      * @stackhpc/sms-lab
 source_repositories:
   kolla:
     community_files:
@@ -30,6 +38,10 @@ source_repositories:
           content: '{{ community_files.codeowners.kayobe_codeowners }}'
           dest: '.github/CODEOWNERS'
   kayobe:
+    community_files:
+      - codeowners:
+          content: '{{ community_files.codeowners.kayobe_codeowners }}'
+          dest: '.github/CODEOWNERS'
   kolla-ansible:
   bifrost:
     ignored_releases:

--- a/ansible/inventory/group_vars/all/source-repositories
+++ b/ansible/inventory/group_vars/all/source-repositories
@@ -97,7 +97,7 @@ source_repositories:
     workflows: '{{ openstack_workflows.elsewhere }}'
     community_files:
       - codeowners:
-          content: '{{ community_files.codeowners.ansible }}'
+          content: '{{ community_files.codeowners.openstack }}'
           dest: '.github/CODEOWNERS'
   ansible-role-os-host-aggregates:
     repository_type: 'ansible'
@@ -132,7 +132,7 @@ source_repositories:
     workflows: '{{ ansible_workflows.role }}'
     community_files:
       - codeowners:
-          content: '{{ community_files.codeowners.ansible }}'
+          content: '{{ community_files.codeowners.batch }}'
           dest: '.github/CODEOWNERS'
   ansible-role-libvirt-vm:
     repository_type: 'ansible'


### PR DESCRIPTION
Include `codeowners` for all repositories. Either `kayobe, openstack or ansible`