### PR TITLE
source-repo-sync: Ignore default branch that is also a release branch

### DIFF
--- a/ansible/roles/source-repo-sync/tasks/configure_repository.yml
+++ b/ansible/roles/source-repo-sync/tasks/configure_repository.yml
@@ -23,7 +23,10 @@
         branch: '{{ default_branch_name.stdout }}',
         workflows: '{{ repository_manifest.workflows.default_branch_only }}',
       }
-  when: repository_manifest.copy_workflows | bool
+  when:
+    - repository_manifest.copy_workflows | bool
+    - not default_branch_name.stdout.startswith('stackhpc/') or
+      default_branch_name.stdout[9:] not in repository_manifest.releases | default([])
 
 - name: Add workflows to supported releases
   include_tasks: tasks/add_workflows.yml
@@ -47,7 +50,10 @@
         branch: '{{ default_branch_name.stdout }}',
         community_files: '{{ repository_manifest.community_files }}',
       }
-  when: repository_manifest.community_files is defined
+  when:
+    - repository_manifest.community_files is defined
+    - not default_branch_name.stdout.startswith('stackhpc/') or
+      default_branch_name.stdout[9:] not in repository_manifest.releases | default([])
 
 - name: Add community files to supported releases
   include_tasks: tasks/add_community_files.yml


### PR DESCRIPTION
We can get into trouble with branch protection rules on the created branches.
