### PR TITLE
source-repo-sync: don't clone submodules

### DIFF
--- a/ansible/roles/source-repo-sync/tasks/configure_repository.yml
+++ b/ansible/roles/source-repo-sync/tasks/configure_repository.yml
@@ -7,6 +7,8 @@
   ansible.builtin.git:
     repo: 'https://{{ owner }}:$GITHUB_TOKEN@github.com/{{ owner }}/{{ repository_manifest.name }}.git'
     dest: '{{ staging_path }}/{{ repository_manifest.name }}'
+    # Don't clone submodules.
+    recursive: no
 
 - name: Get default branch name # noqa command-instead-of-module
   ansible.builtin.command:


### PR DESCRIPTION
If one branch of a repository has a submodule that another does not, the
submodule may get added to the commit.
