### PR TITLE
source-repo-sync: Use correct upstream repo for stackhpc-kayobe-config

### DIFF
--- a/ansible/inventory/group_vars/all/source-repositories
+++ b/ansible/inventory/group_vars/all/source-repositories
@@ -57,6 +57,8 @@ source_repositories:
           - upstream-sync
         elsewhere:
           - tox
+    workflow_args:
+      upstream: 'https://github.com/openstack/kayobe-config'
     community_files:
       - codeowners:
           content: '{{ community_files.codeowners.kayobe }}'

--- a/ansible/roles/source-repo-sync/tasks/configure_repository.yml
+++ b/ansible/roles/source-repo-sync/tasks/configure_repository.yml
@@ -22,6 +22,7 @@
       {
         branch: '{{ default_branch_name.stdout }}',
         workflows: '{{ repository_manifest.workflows.default_branch_only }}',
+        workflow_args: '{{ repository_manifest.workflow_args }}',
       }
   when:
     - repository_manifest.copy_workflows | bool
@@ -36,6 +37,7 @@
         branch: '{{ branch_name }}',
         prefix: 'stackhpc/',
         workflows: '{{ repository_manifest.workflows.elsewhere }}',
+        workflow_args: '{{ repository_manifest.workflow_args }}',
       }
   when: repository_manifest.copy_workflows and repository_manifest.releases is defined
   with_items: '{{ repository_manifest.releases }}'

--- a/ansible/roles/source-repo-sync/tasks/main.yml
+++ b/ansible/roles/source-repo-sync/tasks/main.yml
@@ -26,6 +26,7 @@
             elsewhere: '{{ openstack_workflows.elsewhere |
               difference(item.value.workflows.ignored_workflows.elsewhere | default([])) |
               union(item.value.workflows.additional_workflows.elsewhere | default([])) }}' },
+        workflow_args: '{{ item.value.workflow_args | default({}) }}',
         copy_workflows: '{{ item.value.copy_workflows | default(true) }}',
         community_files: '{{ item.value.community_files | default({}) }}'
       }
@@ -39,6 +40,7 @@
       {
         name: '{{ item.key }}',
         workflows: { default_branch_only: '{{ item.value.workflows }}' },
+        workflow_args: '{{ item.value.workflow_args | default({}) }}',
         copy_workflows: '{{ item.value.copy_workflows | default(true) }}',
         community_files: '{{ item.value.community_files | default({}) }}'
       }

--- a/ansible/roles/source-repo-sync/templates/tag-and-release.jinja
+++ b/ansible/roles/source-repo-sync/templates/tag-and-release.jinja
@@ -9,3 +9,7 @@ permissions:
 jobs:
   tag-and-release:
     uses: stackhpc/.github/.github/workflows/tag-and-release.yml@main
+{% if workflow_manifest.workflow_args.upstream is defined %}
+    with:
+      upstream: {{workflow_manifest.workflow_args.upstream}}
+{% endif %}


### PR DESCRIPTION
The upstream name is different - kayobe-config vs stackhpc-kayobe-config.
