### PR TITLE
Remove Azimuth from Terraform Github

### DIFF
--- a/terraform/github/terraform.tfvars.json
+++ b/terraform/github/terraform.tfvars.json
@@ -135,16 +135,6 @@
         ]
       }
     },
-    "Azimuth": {
-      "description": "Team responsible for Azimuth development",
-      "privacy": "closed",
-      "users": {
-        "maintainers": [],
-        "members": [
-          "stackhpc-ci"
-        ]
-      }
-    },
     "Batch": {
       "description": "Team responsible for Batch development",
       "privacy": "closed",


### PR DESCRIPTION
It was renamed to Platform.