### PR TITLE
Stop syncing and promoting Ubuntu kolla images

### DIFF
--- a/ansible/inventory/group_vars/all/kolla
+++ b/ansible/inventory/group_vars/all/kolla
@@ -127,4 +127,3 @@ kolla_container_images:
 # List of supported base container OS distributions.
 kolla_base_distros:
   - centos
-  - ubuntu


### PR DESCRIPTION
The nova-compute and nova-libvirt images are failing to build, so they
do not have any tags in the repo. This causes syncing and promoting them
to fail.
