### PR TITLE
Support filtering of container images by regex

### DIFF
--- a/.github/workflows/container-promote.yml
+++ b/.github/workflows/container-promote.yml
@@ -3,6 +3,11 @@ name: Promote container repositories
 on:
   workflow_dispatch:
     inputs:
+      filter:
+        description: Space-separated list of regular expressions matching images to promote
+        type: string
+        required: false
+        default: ""
       tag:
         description: Container image tag to promote
         required: true
@@ -38,4 +43,8 @@ jobs:
         source venv/bin/activate &&
         ansible-playbook -i ansible/inventory \
         ansible/dev-pulp-container-promote.yml \
-        -e dev_pulp_repository_container_promotion_tag=${{ github.event.inputs.tag }}
+        -e dev_pulp_repository_container_promotion_tag="$TAG" \
+        -e kolla_container_image_filter="'$FILTER'"
+      env:
+        FILTER: ${{ github.event.inputs.filter }}
+        TAG: ${{ github.event.inputs.tag }}

--- a/.github/workflows/container-sync.yml
+++ b/.github/workflows/container-sync.yml
@@ -2,6 +2,12 @@
 name: Sync container repositories
 on:
   workflow_dispatch:
+    inputs:
+      filter:
+        description: Space-separated list of regular expressions matching images to sync
+        type: string
+        required: false
+        default: ""
 
 env:
   ANSIBLE_FORCE_COLOR: True
@@ -33,16 +39,25 @@ jobs:
       run: |
         source venv/bin/activate &&
         ansible-playbook -i ansible/inventory \
-        ansible/dev-pulp-container-publish.yml
+        ansible/dev-pulp-container-publish.yml \
+        -e kolla_container_image_filter="'$FILTER'"
+      env:
+        FILTER: ${{ github.event.inputs.filter }}
 
     - name: Sync images in test with stackhpc-dev namespace in Ark
       run: |
         source venv/bin/activate &&
         ansible-playbook -i ansible/inventory \
-        ansible/test-pulp-container-sync.yml
+        ansible/test-pulp-container-sync.yml \
+        -e kolla_container_image_filter="'$FILTER'"
+      env:
+        FILTER: ${{ github.event.inputs.filter }}
 
     - name: Publish images in test
       run: |
         source venv/bin/activate &&
         ansible-playbook -i ansible/inventory \
-        ansible/test-pulp-container-publish.yml
+        ansible/test-pulp-container-publish.yml \
+        -e kolla_container_image_filter="'$FILTER'"
+      env:
+        FILTER: ${{ github.event.inputs.filter }}

--- a/ansible/filter_plugins/filters.py
+++ b/ansible/filter_plugins/filters.py
@@ -1,0 +1,36 @@
+# Copyright (c) 2022 StackHPC Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+import re
+
+
+def select_images(images, filter_string):
+    """Select images that match a filter string.
+
+    The filter string is a whitespace-separated list of regular expressions
+    matching image names.
+    """
+    if not filter_string:
+        return images
+    regexes = filter_string.split()
+    patterns = re.compile(r"|".join(regexes).join('()'))
+    return [image for image in images if re.search(patterns, image)]
+
+
+class FilterModule(object):
+
+    def filters(self):
+        return {
+            "select_images": select_images,
+        }

--- a/ansible/inventory/group_vars/all/dev-pulp-containers
+++ b/ansible/inventory/group_vars/all/dev-pulp-containers
@@ -20,7 +20,7 @@ dev_pulp_repository_container_repo_release_common:
 dev_pulp_repository_container_repos_release: >-
   {%- set repos = [] -%}
   {%- for base_distro in kolla_base_distros -%}
-  {%- for image in kolla_container_images -%}
+  {%- for image in kolla_container_images_filtered -%}
   {%- set image_repo = "stackhpc/" ~ base_distro ~ "-source-" ~ image -%}
   {%- set upstream_repo = "stackhpc-dev/" ~ base_distro ~ "-source-" ~ image -%}
   {%- set repo = {"name": image_repo, "upstream_name": upstream_repo} -%}
@@ -38,7 +38,7 @@ dev_pulp_distribution_container_development_common:
 dev_pulp_distribution_container_development: >-
   {%- set distributions = [] -%}
   {%- for base_distro in kolla_base_distros -%}
-  {%- for image in kolla_container_images -%}
+  {%- for image in kolla_container_images_filtered -%}
   {%- set image_repo = "stackhpc-dev/" ~ base_distro ~ "-source-" ~ image -%}
   {%- set distribution = {"name": image_repo, "base_path": image_repo} -%}
   {%- set _ = distributions.append(dev_pulp_distribution_container_development_common | combine(distribution)) -%}
@@ -55,7 +55,7 @@ dev_pulp_distribution_container_release_common:
 dev_pulp_distribution_container_release: >-
   {%- set distributions = [] -%}
   {%- for base_distro in kolla_base_distros -%}
-  {%- for image in kolla_container_images -%}
+  {%- for image in kolla_container_images_filtered -%}
   {%- set image_repo = "stackhpc/" ~ base_distro ~ "-source-" ~ image -%}
   {%- set distribution = {"name": image_repo, "repository": image_repo, "base_path": image_repo} -%}
   {%- set _ = distributions.append(dev_pulp_distribution_container_release_common | combine(distribution)) -%}

--- a/ansible/inventory/group_vars/all/kolla
+++ b/ansible/inventory/group_vars/all/kolla
@@ -128,3 +128,9 @@ kolla_container_images:
 kolla_base_distros:
   - centos
   - ubuntu
+
+# Default filter string for container image repositories.
+kolla_container_image_filter: ""
+
+# List of names of supported Kolla container images after applying filter.
+kolla_container_images_filtered: "{{ kolla_container_images | select_images(kolla_container_image_filter) }}"

--- a/ansible/inventory/group_vars/all/test-pulp-containers
+++ b/ansible/inventory/group_vars/all/test-pulp-containers
@@ -17,7 +17,7 @@ test_pulp_repository_container_repo_common:
 test_pulp_repository_container_repos: >-
   {%- set repos = [] -%}
   {%- for base_distro in kolla_base_distros -%}
-  {%- for image in kolla_container_images -%}
+  {%- for image in kolla_container_images_filtered -%}
   {%- set image_repo = "stackhpc-dev/" ~ base_distro ~ "-source-" ~ image -%}
   {%- set repo = {"name": image_repo} -%}
   {%- set _ = repos.append(test_pulp_repository_container_repo_common | combine(repo)) -%}
@@ -33,7 +33,7 @@ test_pulp_distribution_container_common:
 test_pulp_distribution_container: >-
   {%- set distributions = [] -%}
   {%- for base_distro in kolla_base_distros -%}
-  {%- for image in kolla_container_images -%}
+  {%- for image in kolla_container_images_filtered -%}
   {%- set image_repo = "stackhpc-dev/" ~ base_distro ~ "-source-" ~ image -%}
   {%- set distribution = {"name": image_repo, "repository": image_repo, "base_path": image_repo} -%}
   {%- set _ = distributions.append(test_pulp_distribution_container_common | combine(distribution)) -%}

--- a/ansible/validate-kolla-container-images.yml
+++ b/ansible/validate-kolla-container-images.yml
@@ -35,4 +35,24 @@
           - kolla_container_images_filtered[0] == 'horizon'
           - kolla_container_images_filtered[1] == 'nova-api'
       vars:
-        kolla_container_image_filter: horizon, nova-api
+        kolla_container_image_filter: horizon nova-api
+
+    - name: Assert that Kolla container image list can be filtered to single regexes
+      assert:
+        that:
+          - kolla_container_images_filtered | length == 2
+          - kolla_container_images_filtered[0] == 'glance-api'
+          - kolla_container_images_filtered[1] == 'glance-base'
+      vars:
+        kolla_container_image_filter: "ance-"
+
+    - name: Assert that Kolla container image list can be filtered to multiple regexes
+      assert:
+        that:
+          - kolla_container_images_filtered | length == 4
+          - kolla_container_images_filtered[0] == 'keystone'
+          - kolla_container_images_filtered[1] == 'keystone-base'
+          - kolla_container_images_filtered[2] == 'keystone-fernet'
+          - kolla_container_images_filtered[3] == 'keystone-ssh'
+      vars:
+        kolla_container_image_filter: "ance$ ^keystone"

--- a/ansible/validate-kolla-container-images.yml
+++ b/ansible/validate-kolla-container-images.yml
@@ -1,0 +1,38 @@
+---
+- name: Validate Kolla container image configuration
+  hosts: localhost
+  gather_facts: true
+  vars:
+    num_kolla_container_images: "{{ kolla_container_images | length }}"
+  tasks:
+    - name: Assert that Kolla container image list is defined
+      assert:
+        that:
+          - kolla_container_images is defined
+
+    - name: Assert that Kolla container images are strings
+      assert:
+        that:
+          - kolla_container_images | reject('string') | list | length == 0
+
+    - name: Assert that Kolla container image names are unique
+      assert:
+        that:
+          - kolla_container_images | unique | list | length == num_kolla_container_images | int
+
+    - name: Assert that Kolla container image list can be filtered to single
+      assert:
+        that:
+          - kolla_container_images_filtered | length == 1
+          - kolla_container_images_filtered[0] == 'horizon'
+      vars:
+        kolla_container_image_filter: horizon
+
+    - name: Assert that Kolla container image list can be filtered to multiple
+      assert:
+        that:
+          - kolla_container_images_filtered | length == 2
+          - kolla_container_images_filtered[0] == 'horizon'
+          - kolla_container_images_filtered[1] == 'nova-api'
+      vars:
+        kolla_container_image_filter: horizon, nova-api


### PR DESCRIPTION
Running the full workflows can take a long time, which may be
undesirable when we want to get changes only for a small number of
container images (e.g. for a security or bug fix release).

This change adds the ability to specify a filter to apply to the list of
container images in the various playbooks. The filter is also exposed in
the Github actions workflows.

The filter takes the form of a whitespace-separated list of regular
expressions matching image names. This is the same format that is
accepted by the kolla-build tool.
