### PR TITLE
Revert "Stop syncing and promoting Ubuntu kolla images"

### DIFF
--- a/ansible/inventory/group_vars/all/kolla
+++ b/ansible/inventory/group_vars/all/kolla
@@ -127,6 +127,7 @@ kolla_container_images:
 # List of supported base container OS distributions.
 kolla_base_distros:
   - centos
+  - ubuntu
 
 # Default filter string for container image repositories.
 kolla_container_image_filter: ""


### PR DESCRIPTION
This reverts commit 4938da5179aaf8631fd045e0bb182b0b0394a377.

Ubuntu images now back in action.
