### PR TITLE
Github: Stop using strict mode for protected branches

### DIFF
--- a/terraform/github/branches.tf
+++ b/terraform/github/branches.tf
@@ -24,7 +24,7 @@ resource "github_branch_protection" "ansible_branch_protection" {
 
   required_status_checks {
     contexts = lookup(var.required_status_checks, each.key, [])
-    strict   = true
+    strict   = false
   }
 
   lifecycle {
@@ -53,7 +53,7 @@ resource "github_branch_protection" "azimuth_branch_protection" {
 
   required_status_checks {
     contexts = lookup(var.required_status_checks, each.key, [])
-    strict   = true
+    strict   = false
   }
 
   lifecycle {
@@ -82,7 +82,7 @@ resource "github_branch_protection" "batch_branch_protection" {
 
   required_status_checks {
     contexts = lookup(var.required_status_checks, each.key, [])
-    strict   = true
+    strict   = false
   }
 
   lifecycle {
@@ -115,7 +115,7 @@ resource "github_branch_protection" "kayobe_branch_protection" {
       "tox / Tox py36 with Python 3.6",
       "tox / Tox py38 with Python 3.8",
     ])
-    strict = true
+    strict = false
   }
 
   lifecycle {
@@ -148,7 +148,7 @@ resource "github_branch_protection" "openstack_branch_protection" {
       "tox / Tox py36 with Python 3.6",
       "tox / Tox py38 with Python 3.8",
     ])
-    strict = true
+    strict = false
   }
 
   lifecycle {
@@ -177,7 +177,7 @@ resource "github_branch_protection" "releasetrain_branch_protection" {
 
   required_status_checks {
     contexts = lookup(var.required_status_checks, each.key, [])
-    strict   = true
+    strict   = false
   }
 
   lifecycle {
@@ -206,7 +206,7 @@ resource "github_branch_protection" "smslab_branch_protection" {
 
   required_status_checks {
     contexts = lookup(var.required_status_checks, each.key, [])
-    strict   = true
+    strict   = false
   }
 
   lifecycle {


### PR DESCRIPTION
In theory strict mode helps to ensure you always test the latest
changes. In practice it's a bit of a pain, and is not quite as slick as
Zuul's gating.
