### PR TITLE
Github: allow some things to be destroyed

### DIFF
--- a/terraform/github/repositories.tf
+++ b/terraform/github/repositories.tf
@@ -38,9 +38,6 @@ resource "github_issue_label" "stackhpc_ci_label" {
   name        = "stackhpc-ci"
   color       = "E6E2C0"
   description = "Automated action performed by stackhpc-ci"
-  lifecycle {
-    prevent_destroy = true
-  }
 }
 
 resource "github_issue_label" "workflows_label" {
@@ -49,9 +46,6 @@ resource "github_issue_label" "workflows_label" {
   name        = "workflows"
   color       = "638475"
   description = "Workflow files have been modified"
-  lifecycle {
-    prevent_destroy = true
-  }
 }
 
 resource "github_issue_label" "community_files_label" {
@@ -60,9 +54,6 @@ resource "github_issue_label" "community_files_label" {
   name        = "community-files"
   color       = "3F84E5"
   description = "Community files have been modified"
-  lifecycle {
-    prevent_destroy = true
-  }
 }
 
 data "github_repository" "repositories" {

--- a/terraform/github/teams.tf
+++ b/terraform/github/teams.tf
@@ -13,9 +13,6 @@ resource "github_team_repository" "ansible_repositories" {
   team_id    = resource.github_team.organisation_teams["Ansible"].id
   repository = each.value
   permission = "push"
-  lifecycle {
-    prevent_destroy = true
-  }
 }
 
 resource "github_team_repository" "azimuth_repositories" {
@@ -23,9 +20,6 @@ resource "github_team_repository" "azimuth_repositories" {
   team_id    = resource.github_team.organisation_teams["Azimuth"].id
   repository = each.value
   permission = "push"
-  lifecycle {
-    prevent_destroy = true
-  }
 }
 
 resource "github_team_repository" "batch_repositories" {
@@ -33,9 +27,6 @@ resource "github_team_repository" "batch_repositories" {
   team_id    = resource.github_team.organisation_teams["Batch"].id
   repository = each.value
   permission = "push"
-  lifecycle {
-    prevent_destroy = true
-  }
 }
 
 resource "github_team_repository" "developers_repositories" {
@@ -43,9 +34,6 @@ resource "github_team_repository" "developers_repositories" {
   team_id    = resource.github_team.organisation_teams["Developers"].id
   repository = each.value
   permission = "push"
-  lifecycle {
-    prevent_destroy = true
-  }
 }
 
 resource "github_team_repository" "kayobe_repositories" {
@@ -53,9 +41,6 @@ resource "github_team_repository" "kayobe_repositories" {
   team_id    = resource.github_team.organisation_teams["Kayobe"].id
   repository = each.value
   permission = "push"
-  lifecycle {
-    prevent_destroy = true
-  }
 }
 
 resource "github_team_repository" "openstack_repositories" {
@@ -63,9 +48,6 @@ resource "github_team_repository" "openstack_repositories" {
   team_id    = resource.github_team.organisation_teams["OpenStack"].id
   repository = each.value
   permission = "push"
-  lifecycle {
-    prevent_destroy = true
-  }
 }
 
 resource "github_team_repository" "releasetrain_repositories" {
@@ -73,9 +55,6 @@ resource "github_team_repository" "releasetrain_repositories" {
   team_id    = resource.github_team.organisation_teams["ReleaseTrain"].id
   repository = each.value
   permission = "admin"
-  lifecycle {
-    prevent_destroy = true
-  }
 }
 
 resource "github_team_repository" "smslab_repositories" {
@@ -83,9 +62,6 @@ resource "github_team_repository" "smslab_repositories" {
   team_id    = resource.github_team.organisation_teams["SMSLab"].id
   repository = each.value
   permission = "push"
-  lifecycle {
-    prevent_destroy = true
-  }
 }
 
 resource "github_team_membership" "team_membership" {
@@ -104,7 +80,4 @@ resource "github_team_membership" "team_membership" {
   team_id  = each.value.team_id
   username = each.value.username
   role     = each.value.role
-  lifecycle {
-    prevent_destroy = true
-  }
 }


### PR DESCRIPTION
We need to be very careful to avoid destroying repositories, and the
prevent_destroy lifecycle option helps us do that. However we don't need
to specify it for all resources - many can be easily recreated if
accidentally destroyed.

This change removes prevent_destroy for the following resources:

* github_team_repository (allows repos to be moved from one team to another)
* github_team_membership (allows to easily remove members from a team)
* github_issue_label
