### PR TITLE
Remove admin permission from ReleaseTrain team

### DIFF
--- a/terraform/github/teams.tf
+++ b/terraform/github/teams.tf
@@ -54,7 +54,7 @@ resource "github_team_repository" "releasetrain_repositories" {
   for_each   = toset(var.repositories["ReleaseTrain"])
   team_id    = resource.github_team.organisation_teams["ReleaseTrain"].id
   repository = each.value
-  permission = "admin"
+  permission = "push"
 }
 
 resource "github_team_repository" "smslab_repositories" {


### PR DESCRIPTION
This reverts commit 93b9bfe9bbaf0b5f2e06eb56d014c79650baf433.

The admin permission allows anyone in the team to override branch
protection.
