### PR TITLE
Add tox to ignored_workflows for Neutron

### DIFF
--- a/ansible/inventory/group_vars/all/source-repositories
+++ b/ansible/inventory/group_vars/all/source-repositories
@@ -122,6 +122,10 @@ source_repositories:
       - victoria
       - wallaby
       - xena
+    workflows:
+      ignored_workflows:
+        elsewhere:
+          - tox  
     community_files:
       - codeowners:
           content: "{{ community_files.codeowners.openstack }}"


### PR DESCRIPTION
Neutron Tox py36/38 workflows take over an hour and fail often due to a serialization bug (db updates/deletes done before the table exists).
According to upstream bugs it shows up on slow runners.

To be revisited in future.