### PR TITLE
s-k-c: Update required checks for Rocky 8

### DIFF
--- a/terraform/github/terraform.tfvars.json
+++ b/terraform/github/terraform.tfvars.json
@@ -259,8 +259,10 @@
       "Tox pep8 with Python 3.8",
       "Tox releasenotes with Python 3.8",
       "Build Kayobe Image / Build kayobe image",
-      "aio (OVS) / All in one",
-      "aio (OVN) / All in one"
+      "aio (CentOS OVS) / All in one",
+      "aio (CentOS OVN) / All in one",
+      "aio (Rocky OVS) / All in one",
+      "aio (Rocky OVN) / All in one"
     ],
     "stackhpc-release-train": [
       "Ansible Lint",


### PR DESCRIPTION
In my PR to add the rocky all in one, I've changed the job name to include the OS distribution (we are now testing more than one):

https://github.com/stackhpc/stackhpc-kayobe-config/pull/194

This updates the required checks to match.