### PR TITLE
Add cinder, glance and nova to managed repositories

### DIFF
--- a/ansible/inventory/group_vars/all/source-repositories
+++ b/ansible/inventory/group_vars/all/source-repositories
@@ -89,12 +89,26 @@ source_repositories:
       - codeowners:
           content: "{{ community_files.codeowners.openstack }}"
           dest: ".github/CODEOWNERS"
+  cinder:
+    ignored_releases:
+      - victoria
+    community_files:
+      - codeowners:
+          content: "{{ community_files.codeowners.openstack }}"
+          dest: ".github/CODEOWNERS"
   cloudkitty:
     community_files:
       - codeowners:
           content: "{{ community_files.codeowners.openstack }}"
           dest: ".github/CODEOWNERS"
   cloudkitty-dashboard:
+    community_files:
+      - codeowners:
+          content: "{{ community_files.codeowners.openstack }}"
+          dest: ".github/CODEOWNERS"
+  glance:
+    ignored_releases:
+      - victoria
     community_files:
       - codeowners:
           content: "{{ community_files.codeowners.openstack }}"
@@ -125,6 +139,13 @@ source_repositories:
       ignored_workflows:
         elsewhere:
           - tox
+    community_files:
+      - codeowners:
+          content: "{{ community_files.codeowners.openstack }}"
+          dest: ".github/CODEOWNERS"
+  nova:
+    ignored_releases:
+      - victoria
     community_files:
       - codeowners:
           content: "{{ community_files.codeowners.openstack }}"

--- a/terraform/github/terraform.tfvars.json
+++ b/terraform/github/terraform.tfvars.json
@@ -60,12 +60,15 @@
     "OpenStack": [
       "bifrost",
       "barbican",
+      "cinder",
       "cloudkitty",
       "cloudkitty-dashboard",
+      "glance",
       "ironic-python-agent",
       "magnum",
       "networking-generic-switch",
       "neutron",
+      "nova",
       "stackhpc-inspector-plugins"
     ],
     "ReleaseTrain": [


### PR DESCRIPTION
Adds source repo syncing & GitHub repository config for cinder, glance
and nova repositories.

Nova already exists, the other two do not.

These will be patched to address https://security.openstack.org/ossa/OSSA-2023-002.html
