### PR TITLE
source-repo-sync: Use the force with git add

### DIFF
--- a/ansible/roles/source-repo-sync/tasks/add_community_files.yml
+++ b/ansible/roles/source-repo-sync/tasks/add_community_files.yml
@@ -57,7 +57,7 @@
     - name: Commit changes # noqa command-instead-of-module no-handler
       ansible.builtin.shell:
         cmd: |
-          git add . && git commit -m \
+          git add . --force && git commit -m \
           'feat: automatic update of community files {{ community_manifest.prefix | default("") }}{{ community_manifest.branch }}'
         chdir: '{{ staging_path }}/{{ repository_manifest.name }}'
       when: community_copy.changed | bool

--- a/ansible/roles/source-repo-sync/tasks/add_workflows.yml
+++ b/ansible/roles/source-repo-sync/tasks/add_workflows.yml
@@ -75,7 +75,7 @@
         - name: Commit changes # noqa command-instead-of-module no-handler
           ansible.builtin.shell:
             cmd: |
-              git add . && git commit -m \
+              git add . --force && git commit -m \
               'feat: automatic update of workflows {{ workflow_manifest.prefix | default("") }}{{ workflow_manifest.branch }}'
             chdir: '{{ staging_path }}/{{ repository_manifest.name }}'
           changed_when: true


### PR DESCRIPTION
This argument causes git to add ignored files to the repository. In some
cases there may be an entry in .gitignore that causes any added files to
be ignored. If no files are added, the workflow may fail with the
following:

  nothing to commit, working tree clean

This change fixes the issue by using git add . --force, which ignores
entries in .gitignore.
