### PR TITLE
CI: Update versions used of community GitHub Actions

### DIFF
--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Install Ansible collections
       run: |

--- a/.github/workflows/ansible-validations.yml
+++ b/.github/workflows/ansible-validations.yml
@@ -15,7 +15,7 @@ jobs:
     name: Ansible Validations
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v3
 
       - name: Preparing Vault password file
         run: |

--- a/.github/workflows/container-promote.yml
+++ b/.github/workflows/container-promote.yml
@@ -20,7 +20,7 @@ jobs:
     name: Promote container repositories
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v3
 
     - name: Preparing Vault password file
       run: |

--- a/.github/workflows/container-sync.yml
+++ b/.github/workflows/container-sync.yml
@@ -17,7 +17,7 @@ jobs:
     name: Sync container repositories
     runs-on: [self-hosted, stackhpc-release-train]
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v3
 
     - name: Preparing Vault password file
       run: |

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -7,8 +7,8 @@ jobs:
     name: Build documentation
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
         with:
           python-version: 3.x
       - run: pip install -r docs-requirements.txt

--- a/.github/workflows/docs-publish.yml
+++ b/.github/workflows/docs-publish.yml
@@ -9,8 +9,8 @@ jobs:
     name: Publish documentation
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
         with:
           python-version: 3.x
       - run: pip install -r docs-requirements.txt

--- a/.github/workflows/package-promote.yml
+++ b/.github/workflows/package-promote.yml
@@ -21,7 +21,7 @@ jobs:
     name: Promote package repositories
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v3
 
     - name: Preparing Vault password file
       run: |
@@ -30,7 +30,7 @@ jobs:
         ANSIBLE_VAULT_PASSWORD: ${{ secrets.ANSIBLE_VAULT_PASSWORD }}
 
     - name: Clone StackHPC Kayobe configuration repository
-      uses: actions/checkout@master
+      uses: actions/checkout@v3
       with:
         repository: stackhpc/stackhpc-kayobe-config
         ref: refs/heads/${{ github.event.inputs.kayobe_config_branch }}

--- a/.github/workflows/package-sync.yml
+++ b/.github/workflows/package-sync.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     if: inputs.sync_ark || github.event_name == 'schedule'
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v3
 
     - name: Preparing Vault password file
       run: |
@@ -67,7 +67,7 @@ jobs:
     needs: package-sync-ark
     if: inputs.sync_test || github.event_name == 'schedule'
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v3
 
     - name: Preparing Vault password file
       run: |

--- a/.github/workflows/package-update-kayobe.yml
+++ b/.github/workflows/package-update-kayobe.yml
@@ -63,7 +63,7 @@ jobs:
         run: |
           cd stackhpc-kayobe-config/ &&
           if ! git diff-index --quiet HEAD; then
-            echo "::set-output name=changed::true" &&
+            echo "changed=true" >> $GITHUB_OUTPUT &&
             git diff --color
           fi
 

--- a/.github/workflows/source-repo-sync.yml
+++ b/.github/workflows/source-repo-sync.yml
@@ -22,7 +22,7 @@ jobs:
           git config --global user.email "22933334+stackhpc-ci@users.noreply.github.com" &&
           git config --global user.name "stackhpc-ci"
       - name: Github checkout 🛎
-        uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846
+        uses: actions/checkout@v3
         with:
           persist-credentials: 'false'
       - name: Run ansible playbook 📖

--- a/.github/workflows/terraform-github.yml
+++ b/.github/workflows/terraform-github.yml
@@ -18,7 +18,7 @@ jobs:
       run:
         working-directory: './terraform/github/'
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: hashicorp/setup-terraform@v2
         with:
           cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}


### PR DESCRIPTION
DEV-1359

Syncing the versions of community actions used to the latest major version.

This should avoid deprecation warnings seen in GitHub Actions. For example:

  The  command is deprecated and will be disabled soon. Please upgrade
  to using Environment Files. For more information see:
  https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

  Node.js 12 actions are deprecated. Please update the following actions
  to use Node.js 16: actions/checkout@v2,
  docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9,
  docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38. For
  more information see:
  https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.~
