### PR TITLE
Add actions: read permission to tag & release workflow

### DIFF
--- a/ansible/roles/source-repo-sync/templates/tag-and-release.jinja
+++ b/ansible/roles/source-repo-sync/templates/tag-and-release.jinja
@@ -5,6 +5,7 @@ name: Tag & Release
     branches:
       - stackhpc/{{workflow_manifest.branch}}
 permissions:
+  actions: read
   contents: write
 jobs:
   tag-and-release:


### PR DESCRIPTION
This is required for the serialisation feature added in
https://github.com/stackhpc/.github/pull/24.
