### PR TITLE
Disable sync for Rocky 8.7 BaseOS

### DIFF
--- a/ansible/inventory/group_vars/all/package-repos
+++ b/ansible/inventory/group_vars/all/package-repos
@@ -402,6 +402,9 @@ rpm_package_repos:
     base_path: rocky/8.7/BaseOS/x86_64/os/
     short_name: rocky_8_7_baseos
     distribution_name: rocky-8.7-baseos-
+    # FIXME: Currently failing with:
+    # failed; No declared artifact with relative path "images/boot.iso" for content "<DistributionTree: pk=6dbc199a-b998-45b6-aaec-c2fb36b1fb6a>"
+    sync: false
   - name: Rocky Linux 8.7 - Extras
     url: https://mirror.rockylinux.org/mirrorlist?repo=rocky-extras-8.7&arch=x86_64
     base_path: rocky/8.7/extras/x86_64/os/


### PR DESCRIPTION
Currently failing with:

failed; No declared artifact with relative path "images/boot.iso" for content "<DistributionTree: pk=6dbc199a-b998-45b6-aaec-c2fb36b1fb6a>"
