### PR TITLE
Clean up duplicate publications in test pulp

### DIFF
--- a/.github/workflows/package-sync.yml
+++ b/.github/workflows/package-sync.yml
@@ -91,6 +91,7 @@ jobs:
         ansible-playbook -i ansible/inventory \
         ansible/test-pulp-repo-version-query.yml \
         ansible/test-pulp-repo-sync.yml \
+        ansible/test-pulp-repo-publication-cleanup.yml \
         ansible/test-pulp-repo-publish.yml \
         -e deb_package_repo_filter="'$FILTER'" \
         -e rpm_package_repo_filter="'$FILTER'"

--- a/ansible/test-pulp-repo-publication-cleanup.yml
+++ b/ansible/test-pulp-repo-publication-cleanup.yml
@@ -1,0 +1,78 @@
+---
+# Due to a bug in Pulp (https://github.com/pulp/pulp_rpm/issues/2311), we can
+# end up with multiple publications for a single repository version after
+# performing a sync. This breaks assumptions in the Pulp squeezer modules about
+# uniqueness, causing the rpm_publication module to fail, and breaking sync
+# jobs.
+#
+# This playbook looks for repository versions with multiple publications, and
+# removes the most recent.
+
+- name: Clean up duplicate publications
+  hosts: localhost
+  gather_facts: True
+  vars:
+    pulp_url: "{{ test_pulp_url }}"
+    pulp_username: "{{ test_pulp_username }}"
+    pulp_password: "{{ test_pulp_password }}"
+  tasks:
+    - name: Query repositories
+      pulp.squeezer.rpm_repository:
+        pulp_url: "{{ pulp_url }}"
+        username: "{{ pulp_username }}"
+        password: "{{ pulp_password }}"
+      register: pulp_repos_list
+
+    - name: Query publications
+      pulp.squeezer.rpm_publication:
+        pulp_url: "{{ pulp_url }}"
+        username: "{{ pulp_username }}"
+        password: "{{ pulp_password }}"
+      register: pulp_pubs_list
+
+    - name: Query distributions
+      pulp.squeezer.rpm_distribution:
+        pulp_url: "{{ pulp_url }}"
+        username: "{{ pulp_username }}"
+        password: "{{ pulp_password }}"
+      register: pulp_dists_list
+
+    - block:
+        - name: Show duplicate publications
+          debug:
+            msg: "{{ pubs | sort(attribute='pulp_created') }}"
+          loop: "{{ test_pulp_distribution_rpm }}"
+          loop_control:
+            label: "{{ item.repository }}"
+          when: pubs | length > 1
+
+        - name: Fail if duplicate publications have distributions
+          assert:
+            that: dists | length == 0
+          loop: "{{ test_pulp_distribution_rpm }}"
+          loop_control:
+            label: "{{ item.repository }}"
+          when: pubs | length > 1
+          vars:
+            duplicate_pub: "{{ pubs | sort(attribute='pulp_created') | last }}"
+            dists: "{{ pulp_dists_list.distributions | selectattr('publication', 'equalto', duplicate_pub.pulp_href) }}"
+
+        # Use URI module since pulp.squeezer.rpm_publication fails if there are
+        # multiple matching publications.
+        - name: Destroy duplicate publications
+          uri:
+            url: "{{ pulp_url }}{{ duplicate_pub.pulp_href }}"
+            user: "{{ pulp_username }}"
+            password: "{{ pulp_password }}"
+            method: DELETE
+            status_code: 204
+            force_basic_auth: true
+          loop: "{{ test_pulp_distribution_rpm }}"
+          loop_control:
+            label: "{{ item.repository }}"
+          when: pubs | length > 1
+          vars:
+            duplicate_pub: "{{ pubs | sort(attribute='pulp_created') | last }}"
+      vars:
+        repo: "{{ pulp_repos_list.repositories | selectattr('name', 'equalto', item.repository) | first }}"
+        pubs: "{{ pulp_pubs_list.publications | selectattr('repository_version', 'equalto', repo.latest_version_href) }}"


### PR DESCRIPTION
We have just seen the duplicate publication issue in Test Pulp. Add the cleanup script there too.
