### PR TITLE
fix: `workflow` missing empty list

### DIFF
--- a/ansible/inventory/group_vars/all/source-repositories
+++ b/ansible/inventory/group_vars/all/source-repositories
@@ -484,14 +484,14 @@ source_repositories:
           dest: ".github/CODEOWNERS"
   caas-slurm-appliance:
     repository_type: "ansible"
-    workflows:
+    workflows: []
     community_files:
       - codeowners:
           content: "{{ community_files.codeowners.batch }}"
           dest: ".github/CODEOWNERS"
   ansible-slurm-appliance:
     repository_type: "ansible"
-    workflows:
+    workflows: []
     community_files:
       - codeowners:
           content: "{{ community_files.codeowners.batch }}"


### PR DESCRIPTION
[#172](https://github.com/stackhpc/stackhpc-release-train/actions/runs/4253329599) failed when attempting to to iterate over workflows which don't exist. This isn't an issue however for `caas-slurm-appliance` and `ansible-slurm-appliance` they were missing `[]` which would allow Ansible to skip over the empty list as opposed to failing.