### PR TITLE
Prune zed forks

### DIFF
--- a/ansible/inventory/group_vars/all/source-repositories
+++ b/ansible/inventory/group_vars/all/source-repositories
@@ -131,6 +131,7 @@ source_repositories:
       - victoria
       - wallaby
       - xena
+      - zed
     workflows:
       ignored_workflows:
         elsewhere:
@@ -155,6 +156,7 @@ source_repositories:
       - victoria
       - wallaby
       - xena
+      - zed
     workflows:
       ignored_workflows:
         elsewhere:
@@ -168,11 +170,14 @@ source_repositories:
       - codeowners:
           content: "{{ community_files.codeowners.openstack }}"
           dest: ".github/CODEOWNERS"
+    ignored_releases:
+      - zed
   ironic-ui:
     ignored_releases:
       - victoria
       - wallaby
       - xena
+      - zed
     workflows:
       ignored_workflows:
         elsewhere:
@@ -193,6 +198,7 @@ source_repositories:
       - victoria
       - wallaby
       - xena
+      - zed
     workflows:
       ignored_workflows:
         elsewhere:
@@ -234,6 +240,7 @@ source_repositories:
       - victoria
       - wallaby
       - xena
+      - zed
     workflows:
       ignored_workflows:
         elsewhere:


### PR DESCRIPTION
The os-cherry-pop.py script from naming-things-is-hard didn't find any cherry picks to pull in for:
designate-dashboard
horizon
ironic-python-agent
ironic-ui
magnum-ui
octavia-dashboard

There may be more forks to prune once the cherry picks have been evaluated