### PR TITLE
Add specific status checks for Zed branches

### DIFF
--- a/docs/usage/source-code-ci.md
+++ b/docs/usage/source-code-ci.md
@@ -26,21 +26,12 @@ The table below contains the different workflows with a description of each and 
 
 OpenStack use [Tox](https://wiki.openstack.org/wiki/Testing) to manage the unit tests and style checks for the various projects they maintain.
 Therefore, when a `pull request` is opened the tox workflow will automatically perform a series of unit tests and linting in order ensure correctness and style guidelines are being met.
-The workflow will run in both python 3.6 and python 3.8 environments.
-This can be controlled within the strategy matrix of the workflow. 
+The python environment will depend on the branch pre-Zed, python 3.6 and python 3.8 will be tested. From Zed onward, python 3.8 and python 3.10 will be tested.
+This can be controlled within the strategy matrix of the workflow.
 The Python versions should correspond to those used in the supported OS distributions for a particular release.
+The source for the workflow can be found [here](https://github.com/stackhpc/.github/blob/main/.github/workflows/tox.yml).
+It is managed centrally and imported into all downstream branches.
 
-```yaml
-strategy:
-  matrix:
-    include:
-      - environment: py36
-        python-version: 3.6
-      - environment: py38
-        python-version: 3.8
-      - environment: pep8
-        python-version: 3.8
-```
 
 ### Tag & Release
 

--- a/terraform/github/branches.tf
+++ b/terraform/github/branches.tf
@@ -61,11 +61,11 @@ resource "github_branch_protection" "batch_branch_protection" {
   }
 }
 
-resource "github_branch_protection" "kayobe_branch_protection" {
+resource "github_branch_protection" "kayobe_branch_protection_py_3-6" {
   for_each      = toset(var.repositories["Kayobe"])
   repository_id = data.github_repository.repositories[each.key].node_id
 
-  pattern                         = "stackhpc/**"
+  pattern                         = "stackhpc/(victoria|wallaby|xena|yoga)"
   require_conversation_resolution = true
   allows_deletions                = false
   allows_force_pushes             = false
@@ -94,11 +94,44 @@ resource "github_branch_protection" "kayobe_branch_protection" {
   }
 }
 
-resource "github_branch_protection" "openstack_branch_protection" {
+resource "github_branch_protection" "kayobe_branch_protection_py_3-10" {
+  for_each      = toset(var.repositories["Kayobe"])
+  repository_id = data.github_repository.repositories[each.key].node_id
+
+  pattern                         = "stackhpc/zed"
+  require_conversation_resolution = true
+  allows_deletions                = false
+  allows_force_pushes             = false
+
+  required_pull_request_reviews {
+    dismiss_stale_reviews           = true
+    require_code_owner_reviews      = true
+    required_approving_review_count = 1
+  }
+
+  push_restrictions = [
+    resource.github_team.organisation_teams["Developers"].node_id
+  ]
+
+  required_status_checks {
+    contexts = lookup(var.required_status_checks, each.key, [
+      "tox / Tox pep8 with Python 3.10",
+      "tox / Tox py310 with Python 3.10",
+      "tox / Tox py38 with Python 3.8",
+    ])
+    strict = false
+  }
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "github_branch_protection" "openstack_branch_protection_py_3-6" {
   for_each      = toset(var.repositories["OpenStack"])
   repository_id = data.github_repository.repositories[each.key].node_id
 
-  pattern                         = "stackhpc/**"
+  pattern                         = "stackhpc/(victoria|wallaby|xena|yoga)"
   require_conversation_resolution = true
   allows_deletions                = false
   allows_force_pushes             = false
@@ -117,6 +150,38 @@ resource "github_branch_protection" "openstack_branch_protection" {
     contexts = lookup(var.required_status_checks, each.key, [
       "tox / Tox pep8 with Python 3.8",
       "tox / Tox py36 with Python 3.6",
+      "tox / Tox py38 with Python 3.8",
+    ])
+    strict = false
+  }
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "github_branch_protection" "openstack_branch_protection_py_3-10" {
+  for_each      = toset(var.repositories["OpenStack"])
+  repository_id = data.github_repository.repositories[each.key].node_id
+
+  pattern                         = "stackhpc/zed"
+  require_conversation_resolution = true
+  allows_deletions                = false
+  allows_force_pushes             = false
+
+  push_restrictions = [
+    resource.github_team.organisation_teams["Developers"].node_id
+  ]
+
+  required_pull_request_reviews {
+    dismiss_stale_reviews           = true
+    require_code_owner_reviews      = true
+    required_approving_review_count = 1
+  }
+
+  required_status_checks {
+    contexts = lookup(var.required_status_checks, each.key, [
+      "tox / Tox pep8 with Python 3.10",
+      "tox / Tox py310 with Python 3.10",
       "tox / Tox py38 with Python 3.8",
     ])
     strict = false


### PR DESCRIPTION
Zed branches swap support for python 3.6 with python 3.10, necessitating a change in the required tox workflows: