### PR TITLE
Disable prevent_destroy on kayobe & openstack

### DIFF
--- a/terraform/github/branches.tf
+++ b/terraform/github/branches.tf
@@ -90,7 +90,7 @@ resource "github_branch_protection" "kayobe_branch_protection" {
   }
 
   lifecycle {
-    prevent_destroy = true
+    prevent_destroy = false
   }
 }
 
@@ -123,7 +123,7 @@ resource "github_branch_protection" "openstack_branch_protection" {
   }
 
   lifecycle {
-    prevent_destroy = true
+    prevent_destroy = false
   }
 }
 


### PR DESCRIPTION
The required status checks (CI workflows) are changing for repositories in the kayobe and openstack groups. prevent_destroy must be disabled for the changes to take place