### PR TITLE
Add a workflow template that lints Ansible collections

### DIFF
--- a/ansible/inventory/group_vars/all/source-repositories
+++ b/ansible/inventory/group_vars/all/source-repositories
@@ -16,6 +16,7 @@ openstack_workflows:
     - tag-and-release
 ansible_workflows:
   collection:
+    - lint-collection
     - publish-collection
   role:
     - publish-role

--- a/ansible/roles/source-repo-sync/templates/lint-collection.jinja
+++ b/ansible/roles/source-repo-sync/templates/lint-collection.jinja
@@ -1,0 +1,7 @@
+---
+name: Ansible collection linters
+'on':
+  pull_request:
+jobs:
+  tox:
+    uses: stackhpc/.github/.github/workflows/lint-collection.yml@main

--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -203,6 +203,7 @@ Therefore, this workflow will once a week make a pull request against any of the
 * **Tox**: in order to ensure that commits to the repositories are correct and follow style guidelines we can utilise tox which can automate the unit testing and linting of the codebase. 
 This workflow will run anytime a push is made or a pull request to one of the active release branches.
 * **Tag & Release**: various software and packages depend on the repositories therefore it is important that tags are made and releases are published.
+* **Ansible collection linters**: linters and sanity tests for Ansible collections.
 
 ### Ansible
 

--- a/docs/usage/source-code-ci.md
+++ b/docs/usage/source-code-ci.md
@@ -15,6 +15,7 @@ The table below contains the different workflows with a description of each and 
 | **Upstream Sync**      | Keep our downstream fork up-to-date with the upstream counterpart                           | OpenStack            |
 | **Tag & Release**      | Generate an new tag and accompanying release whenever a commit is pushed to select branches | OpenStack            |
 | **Tox**                | Perform linting and unit testing                                                            | OpenStack            |
+| **Lint Collection**    | Perform linting and sanity checks on Ansible collections                                    | Ansible (Collection) |
 | **Publish Role**       | Publish the Ansible Role on Ansible Galaxy                                                  | Ansible (Role)       |
 | **Publish Collection** | Publish the Ansible Collection on Ansible Galaxy                                            | Ansible (Collection) |
 
@@ -59,6 +60,12 @@ This can be changed in the [workflow template within the .github repository](htt
     - cron: '15 8 * * 1'
   workflow_dispatch:
 ```
+
+### Lint Collection
+
+Ansible collections are linted using [Ansible lint](https://ansible.readthedocs.io/projects/lint/), and sanity checked using the `ansible-test sanity` command.
+These checks run against pull requests to Ansible collection repositories and use a matrix to test multiple versions of Ansible.
+The tested versions of Ansible should generally correspond to those used by supported versions of Kayobe and Kolla.
 
 ### Publish Collection/Role
 


### PR DESCRIPTION
This uses the new reusable collection linter workflow in .github repo.
