### PR TITLE
Fix nightly matrix sync inputs not being used

### DIFF
--- a/.github/workflows/package-sync.yml
+++ b/.github/workflows/package-sync.yml
@@ -4,20 +4,17 @@ on:
   workflow_call:
     inputs:
       sync_ark:
-        required: false
         description: Sync package repositories in Ark
-        default: true
         type: boolean
+        required: true
       sync_test:
-        required: false
         description: Sync package repositories in Test Pulp
-        default: true
         type: boolean
+        required: true
       filter:
         description: Space-separated list of regular expressions matching short_name of repositories to sync
         type: string
-        required: false
-        default: ""
+        required: true
   workflow_dispatch:
     inputs:
       sync_ark:
@@ -63,7 +60,7 @@ jobs:
         -e deb_package_repo_filter="'$FILTER'" \
         -e rpm_package_repo_filter="'$FILTER'"
       env:
-        FILTER: ${{ github.event.inputs.filter }}
+        FILTER: ${{ inputs.filter }}
 
   package-sync-test:
     name: Sync package repositories in test
@@ -90,4 +87,4 @@ jobs:
         -e deb_package_repo_filter="'$FILTER'" \
         -e rpm_package_repo_filter="'$FILTER'"
       env:
-        FILTER: ${{ github.event.inputs.filter }}
+        FILTER: ${{ inputs.filter }}


### PR DESCRIPTION
Nightly syncs are currently timing out because they are not correctly using the filter: https://github.com/stackhpc/stackhpc-release-train/actions/runs/5686387307/job/15413065535
I believe this is because of a small comment [here](https://docs.github.com/en/enterprise-cloud@latest/actions/using-workflows/events-that-trigger-workflows#workflow_call) that says the webhook event payload for workflow_call events is the same as the caller workflow. Therefore because the caller has no inputs defined, they are not used in the reusable workflow. 