### PR TITLE
Define lint_pip_dependencies for stackhpc.hashicorp collection lint

### DIFF
--- a/ansible/inventory/group_vars/all/source-repositories
+++ b/ansible/inventory/group_vars/all/source-repositories
@@ -545,6 +545,8 @@ source_repositories:
   ansible-collection-hashicorp:
     repository_type: "ansible"
     workflows: "{{ ansible_workflows.collection }}"
+    workflow_args:
+      lint_pip_dependencies: "git+https://github.com/stackhpc/ansible-modules-hashivault@stackhpc"
     community_files:
       - codeowners:
           content: "{{ community_files.codeowners.ansible }}"

--- a/ansible/roles/source-repo-sync/templates/lint-collection.jinja
+++ b/ansible/roles/source-repo-sync/templates/lint-collection.jinja
@@ -5,3 +5,7 @@ name: Ansible collection linters
 jobs:
   lint:
     uses: stackhpc/.github/.github/workflows/lint-collection.yml@main
+{% if workflow_manifest.workflow_args.lint_pip_dependencies is defined %}
+    with:
+      upstream: {{ workflow_manifest.workflow_args.lint_pip_dependencies }}
+{% endif %}


### PR DESCRIPTION
This ensures we install the hashivault modules required to make the linting pass.
