### PR TITLE
Stop syncing EOL Xena for Kolla projects

### DIFF
--- a/ansible/inventory/group_vars/all/source-repositories
+++ b/ansible/inventory/group_vars/all/source-repositories
@@ -43,6 +43,7 @@ source_repositories:
     ignored_releases:
       - victoria
       - wallaby
+      - xena
     community_files:
       - codeowners:
           content: "{{ community_files.codeowners.kayobe }}"
@@ -51,6 +52,7 @@ source_repositories:
     ignored_releases:
       - victoria
       - wallaby
+      - xena
     community_files:
       - codeowners:
           content: "{{ community_files.codeowners.kayobe }}"
@@ -66,6 +68,7 @@ source_repositories:
     ignored_releases:
       - victoria
       - wallaby
+      - xena
     community_files:
       - codeowners:
           content: "{{ community_files.codeowners.kayobe }}"


### PR DESCRIPTION
Xena is now EOL in upstream Kolla projects. Attempting to sync will fail because the stable/xena branches have been deleted.