### PR TITLE
Bump stackhpc.pulp to 0.5.4

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -1,6 +1,6 @@
 collections:
   - name: stackhpc.pulp
-    version: 0.5.2
+    version: 0.5.4
   - name: community.crypto
     version: 2.0.2
   - name: pulp.squeezer


### PR DESCRIPTION
This includes retries for package & container repo tasks.
