### PR TITLE
Remove caso from rocky unbuildable images

### DIFF
--- a/ansible/inventory/group_vars/all/kolla
+++ b/ansible/inventory/group_vars/all/kolla
@@ -142,7 +142,6 @@ kolla_unbuildable_images:
       - skyline-apiserver
       - skyline-console
     rocky:
-      - caso
       - elasticsearch
       - elasticsearch-curator
       - iscsid


### PR DESCRIPTION
It is now buildable and images exist in Ark.
