### PR TITLE
Run terraform-github workflow more often

### DIFF
--- a/.github/workflows/terraform-github.yml
+++ b/.github/workflows/terraform-github.yml
@@ -4,10 +4,14 @@ name: Terraform GitHub
     branches: [main]
     paths:
       - 'terraform/github/**'
+      - '.github/workflows/terraform-github.yml'
+      - 'ansible/inventory/group_vars/all/source-repositories'
   pull_request:
     branches: [main]
     paths:
       - 'terraform/github/**'
+      - '.github/workflows/terraform-github.yml'
+      - 'ansible/inventory/group_vars/all/source-repositories'
 env:
   TF_VAR_GITHUB_APP_PEM_FILE: ${{ secrets.TF_VAR_GITHUB_APP_PEM_FILE }}
 jobs:


### PR DESCRIPTION
The terraform-github workflow previously only ran when changes where made to terraform/github/**
This change also activates the workflow when changes are made to either the workflow itself or the source-repositories vars file.