### PR TITLE
Rename Ansible roles, stop pushing linters on cephadm collection

### DIFF
--- a/ansible/inventory/group_vars/all/source-repositories
+++ b/ansible/inventory/group_vars/all/source-repositories
@@ -306,7 +306,7 @@ source_repositories:
       - codeowners:
           content: "{{ community_files.codeowners.ansible }}"
           dest: ".github/CODEOWNERS"
-  ansible-role-os-networks:
+  os-networks:
     repository_type: "ansible"
     workflows: "{{ ansible_workflows.role }}"
     community_files:
@@ -502,7 +502,7 @@ source_repositories:
       - codeowners:
           content: "{{ community_files.codeowners.ansible }}"
           dest: ".github/CODEOWNERS"
-  ansible-role-dell-powerconnect-switch:
+  dell-powerconnect-switch:
     repository_type: "ansible"
     workflows: "{{ ansible_workflows.role }}"
     community_files:
@@ -523,7 +523,7 @@ source_repositories:
       - codeowners:
           content: "{{ community_files.codeowners.ansible }}"
           dest: ".github/CODEOWNERS"
-  ansible-role-mellanox-switch:
+  mellanox-switch:
     repository_type: "ansible"
     workflows: "{{ ansible_workflows.role }}"
     community_files:

--- a/ansible/inventory/group_vars/all/source-repositories
+++ b/ansible/inventory/group_vars/all/source-repositories
@@ -553,7 +553,9 @@ source_repositories:
           dest: ".github/CODEOWNERS"
   ansible-collection-cephadm:
     repository_type: "ansible"
-    workflows: "{{ ansible_workflows.collection }}"
+    workflows:
+      # Linters workflows not currently working on the Cephadm collection.
+      - publish-collection
     community_files:
       - codeowners:
           content: "{{ community_files.codeowners.ansible }}"

--- a/terraform/github/terraform.tfvars.json
+++ b/terraform/github/terraform.tfvars.json
@@ -3,7 +3,7 @@
   "repositories": {
     "Ansible": [
       "ansible-role-os-host-aggregates",
-      "ansible-role-os-networks",
+      "os-networks",
       "ansible-role-os-projects",
       "ansible-role-libvirt-host",
       "ansible-role-libvirt-vm",
@@ -30,10 +30,10 @@
       "stackhpc.ipmi-exporter",
       "ansible-role-mlnx-ufm",
       "ansible-role-rundeck",
-      "ansible-role-dell-powerconnect-switch",
+      "dell-powerconnect-switch",
       "drac-facts",
       "ansible-role-gluster-cluster",
-      "ansible-role-mellanox-switch",
+      "mellanox-switch",
       "ansible-role-os-config",
       "ansible-role-os-deploy-templates",
       "ansible-role-mlnx-neo",


### PR DESCRIPTION
- Rename Ansible role repositories to match new reality
- cephadm: Stop proposing linters workflow
