### PR TITLE
Add a step needs to be done before syncing package repo

### DIFF
--- a/docs/usage/content-howto.md
+++ b/docs/usage/content-howto.md
@@ -7,7 +7,7 @@ That is the aim of this page.
 
 Update one or more package repositories to a new version, then build new Kolla container images from those repositories.
 
-* Add new pacakage repositories to update at [`package-repos`](https://github.com/stackhpc/stackhpc-release-train/blob/main/ansible/inventory/group_vars/all/package-repos) (If required e.g. new point release)
+* If the repository URL has changed e.g. a new minor version has been released, add new package repositories to [`package-repos`](https://github.com/stackhpc/stackhpc-release-train/blob/main/ansible/inventory/group_vars/all/package-repos)
 * [Sync package repositories](content-workflows.md#syncing-package-repositories) (optional: runs nightly as a scheduled GitHub Action)
 * [Update Kayobe repository versions](content-workflows.md#updating-package-repository-versions-in-kayobe-configuration)
 * [Build & push Kolla container images](content-workflows.md#building-container-images)

--- a/docs/usage/content-howto.md
+++ b/docs/usage/content-howto.md
@@ -7,6 +7,7 @@ That is the aim of this page.
 
 Update one or more package repositories to a new version, then build new Kolla container images from those repositories.
 
+* Add package repositories to update at [`package-repos`](https://github.com/stackhpc/stackhpc-release-train/blob/main/ansible/inventory/group_vars/all/package-repos)
 * [Sync package repositories](content-workflows.md#syncing-package-repositories) (optional: runs nightly as a scheduled GitHub Action)
 * [Update Kayobe repository versions](content-workflows.md#updating-package-repository-versions-in-kayobe-configuration)
 * [Build & push Kolla container images](content-workflows.md#building-container-images)

--- a/docs/usage/content-howto.md
+++ b/docs/usage/content-howto.md
@@ -7,7 +7,7 @@ That is the aim of this page.
 
 Update one or more package repositories to a new version, then build new Kolla container images from those repositories.
 
-* Add package repositories to update at [`package-repos`](https://github.com/stackhpc/stackhpc-release-train/blob/main/ansible/inventory/group_vars/all/package-repos)
+* Add new pacakage repositories to update at [`package-repos`](https://github.com/stackhpc/stackhpc-release-train/blob/main/ansible/inventory/group_vars/all/package-repos) (If required e.g. new point release)
 * [Sync package repositories](content-workflows.md#syncing-package-repositories) (optional: runs nightly as a scheduled GitHub Action)
 * [Update Kayobe repository versions](content-workflows.md#updating-package-repository-versions-in-kayobe-configuration)
 * [Build & push Kolla container images](content-workflows.md#building-container-images)


### PR DESCRIPTION
I added this step to make sure the updating repository is actually defined before running the `Sync package repositories` action.
Maybe this step is looking obvious but I missed it while trying RL9.3 update test.