### PR TITLE
upstream sync: Sort releases for deterministic workflows

### DIFF
--- a/ansible/roles/source-repo-sync/tasks/main.yml
+++ b/ansible/roles/source-repo-sync/tasks/main.yml
@@ -18,7 +18,7 @@
         name: '{{ item.key }}',
         releases:
           '{{ default_releases | difference(item.value.ignored_releases | default([])) |
-          union(item.value.additional_releases | default([])) }}',
+          union(item.value.additional_releases | default([])) | sort }}',
         workflows:
           { default_branch_only: '{{ openstack_workflows.default_branch_only  |
               difference(item.value.workflows.ignored_workflows.default_branch_only | default([])) |


### PR DESCRIPTION
For some reason the most recent source repo sync workflow has created
PRs with upstream sync workflow jobs in a random order. This is not good
as they will keep changing over time. Sort the jobs based on the release
name.
