### PR TITLE
Increase container-sync workflow timeout to 720 minutes

### DIFF
--- a/.github/workflows/container-sync.yml
+++ b/.github/workflows/container-sync.yml
@@ -29,6 +29,7 @@ jobs:
   container-sync:
     name: Sync container repositories
     runs-on: [self-hosted, stackhpc-release-train]
+    timeout-minutes: 720
     steps:
     - name: Checkout
       uses: actions/checkout@v3


### PR DESCRIPTION
When there is a full set of new images we often see timeouts after 6h. Increase to 12h.
