### PR TITLE
Stop promoting letsencrypt images

### DIFF
--- a/ansible/inventory/group_vars/all/kolla
+++ b/ansible/inventory/group_vars/all/kolla
@@ -139,16 +139,25 @@ kolla_container_images:
 kolla_unbuildable_images:
   old_scheme:
     ubuntu:
+      - haproxy-ssh
+      - letsencrypt-lego
+      - letsencrypt-webserver
       - skyline-apiserver
       - skyline-console
     centos:
+      - haproxy-ssh
+      - letsencrypt-lego
+      - letsencrypt-webserver
       - skyline-apiserver
       - skyline-console
     rocky:
       - elasticsearch
       - elasticsearch-curator
+      - haproxy-ssh
       - iscsid
       - kibana
+      - letsencrypt-lego
+      - letsencrypt-webserver
       - prometheus-server
       - skyline-apiserver
       - skyline-console


### PR DESCRIPTION
These images are in Antelope only. Adding them to kolla_unbuildable_images.old_scheme will prevent them from being  synced in releases prior to Antelope.

Attempting to do so triggers the following error:

```
failed: [localhost] (item={'allow_missing': True, 'src_repo': 'stackhpc-dev/rocky-source-haproxy-ssh', 'src_is_push': True, 'repository': 'stackhpc/rocky-source-haproxy-ssh', 'tags': ['yoga-20231218T141822']}) => {"ansible_loop_var": "item", "changed": false, "item": {"allow_missing": true, "repository": "stackhpc/rocky-source-haproxy-ssh", "src_is_push": true, "src_repo": "stackhpc-dev/rocky-source-haproxy-ssh", "tags": ["yoga-20231218T141822"]}, "msg": "Failed to find repository ({'name': 'stackhpc-dev/rocky-source-haproxy-ssh'})."}
```

When running https://github.com/stackhpc/stackhpc-release-train/actions/workflows/container-promote.yml.

See: https://github.com/stackhpc/stackhpc-release-train/commit/defe76774d20c42160c2688ca904a4f15bb621a9