### PR TITLE
Separate out repos for Docker CE Ubuntu Jammy/Focal

### DIFF
--- a/ansible/inventory/group_vars/all/package-repos
+++ b/ansible/inventory/group_vars/all/package-repos
@@ -98,17 +98,32 @@ deb_package_repos:
     distribution_name: ubuntu-jammy-security-
 
   # Third-party repositories
-  - name: Docker CE for Ubuntu
+
+  ## Separate repositories for each distribution because
+  ## https://github.com/pulp/pulp_deb/issues/921
+  - name: Docker CE for Ubuntu Focal
     url: https://download.docker.com/linux/ubuntu
     policy: immediate
     architectures: amd64
-    distributions: focal jammy
+    distributions: focal
     components: stable
     mirror: true
     mode: verbatim
-    base_path: docker-ce/ubuntu/
-    short_name: docker_ce_ubuntu
-    distribution_name: docker-ce-for-ubuntu-
+    base_path: docker-ce/ubuntu-focal/
+    short_name: docker_ce_ubuntu_focal
+    distribution_name: docker-ce-for-ubuntu-focal-
+
+  - name: Docker CE for Ubuntu Jammy
+    url: https://download.docker.com/linux/ubuntu
+    policy: immediate
+    architectures: amd64
+    distributions: jammy
+    components: stable
+    mirror: true
+    mode: verbatim
+    base_path: docker-ce/ubuntu-jammy/
+    short_name: docker_ce_ubuntu_jammy
+    distribution_name: docker-ce-for-ubuntu-jammy-
 
 # Default filter string for Deb package repositories.
 deb_package_repo_filter: ""

--- a/ansible/validate-deb-repos.yml
+++ b/ansible/validate-deb-repos.yml
@@ -58,18 +58,18 @@
       assert:
         that:
           - deb_package_repos_filtered | length == 1
-          - deb_package_repos_filtered[0].short_name == 'ubuntu_focal'
+          - deb_package_repos_filtered[0].short_name == 'ubuntu_jammy_security'
       vars:
-        deb_package_repo_filter: ubuntu_focal$
+        deb_package_repo_filter: ubuntu_jammy_security$
 
     - name: Assert that Deb package repository list can be filtered to multiple
       assert:
         that:
           - deb_package_repos_filtered | length == 2
-          - deb_package_repos_filtered[0].short_name == 'ubuntu_focal'
-          - deb_package_repos_filtered[1].short_name == 'docker_ce_ubuntu'
+          - deb_package_repos_filtered[0].short_name == 'ubuntu_jammy_security'
+          - deb_package_repos_filtered[1].short_name == 'docker_ce_ubuntu_jammy'
       vars:
-        deb_package_repo_filter: docker_ce_ubuntu ubuntu_focal$
+        deb_package_repo_filter: docker_ce_ubuntu_jammy ubuntu_jammy_security$
 
     - name: Assert that dev package repository list is defined
       assert:


### PR DESCRIPTION
[Suggested](https://github.com/pulp/pulp_deb/issues/994#issuecomment-1903522436) as a fix for sync failures causing the following log message:

> Cannot create repository version since there are newly added packages with the same name, version, and architecture, but a different checksum. If the log level is DEBUG, you can find a list of affected packages in the Pulp log.