### PR TITLE
Update git checkout action to v4

### DIFF
--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Install Ansible collections
       run: |

--- a/.github/workflows/ansible-validations.yml
+++ b/.github/workflows/ansible-validations.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Release Train & dependencies
         uses: ./.github/actions/setup

--- a/.github/workflows/container-promote.yml
+++ b/.github/workflows/container-promote.yml
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Setup Release Train & dependencies
       uses: ./.github/actions/setup

--- a/.github/workflows/container-publish.yml
+++ b/.github/workflows/container-publish.yml
@@ -29,7 +29,7 @@ jobs:
     name: Publish container repositories
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Preparing Vault password file
       run: |

--- a/.github/workflows/container-sync.yml
+++ b/.github/workflows/container-sync.yml
@@ -32,7 +32,7 @@ jobs:
     timeout-minutes: 720
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Setup Release Train & dependencies
       uses: ./.github/actions/setup

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -7,7 +7,7 @@ jobs:
     name: Build documentation
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-python@v4
         with:
           python-version: 3.x

--- a/.github/workflows/docs-publish.yml
+++ b/.github/workflows/docs-publish.yml
@@ -9,7 +9,7 @@ jobs:
     name: Publish documentation
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-python@v4
         with:
           python-version: 3.x

--- a/.github/workflows/package-promote.yml
+++ b/.github/workflows/package-promote.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Setup Release Train & dependencies
       uses: ./.github/actions/setup
@@ -31,7 +31,7 @@ jobs:
         vault-password-file: ${{ env.ANSIBLE_VAULT_PASSWORD_FILE }}
 
     - name: Clone StackHPC Kayobe configuration repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         repository: stackhpc/stackhpc-kayobe-config
         ref: refs/heads/${{ github.event.inputs.kayobe_config_branch }}

--- a/.github/workflows/package-sync-version-test-pulp.yml
+++ b/.github/workflows/package-sync-version-test-pulp.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: arc-release-train-runner
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Setup Release Train & dependencies
       uses: ./.github/actions/setup

--- a/.github/workflows/package-sync.yml
+++ b/.github/workflows/package-sync.yml
@@ -43,7 +43,7 @@ jobs:
     steps:
 
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Setup Release Train & dependencies
       uses: ./.github/actions/setup
@@ -69,7 +69,7 @@ jobs:
     if: inputs.sync_test
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Setup Release Train & dependencies
       uses: ./.github/actions/setup

--- a/.github/workflows/package-update-kayobe.yml
+++ b/.github/workflows/package-update-kayobe.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Release Train & dependencies
         uses: ./.github/actions/setup
@@ -31,7 +31,7 @@ jobs:
           vault-password-file: ${{ env.ANSIBLE_VAULT_PASSWORD_FILE }}
 
       - name: Clone StackHPC Kayobe configuration repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: stackhpc/stackhpc-kayobe-config
           ref: refs/heads/${{ github.event.inputs.kayobe_config_branch }}

--- a/.github/workflows/source-repo-sync.yml
+++ b/.github/workflows/source-repo-sync.yml
@@ -22,7 +22,7 @@ jobs:
           git config --global user.email "22933334+stackhpc-ci@users.noreply.github.com" &&
           git config --global user.name "stackhpc-ci"
       - name: Github checkout 🛎
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           persist-credentials: 'false'
       - name: Run ansible playbook 📖

--- a/.github/workflows/terraform-github-import.yml
+++ b/.github/workflows/terraform-github-import.yml
@@ -19,7 +19,7 @@ jobs:
         working-directory: './terraform/github/'
     steps:
       - name: GitHub Checkout 🛎
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup Python 🐍
         uses: actions/setup-python@v4
         with:

--- a/.github/workflows/terraform-github.yml
+++ b/.github/workflows/terraform-github.yml
@@ -18,7 +18,7 @@ jobs:
       run:
         working-directory: './terraform/github/'
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: hashicorp/setup-terraform@v2
         with:
           cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}


### PR DESCRIPTION
Continuing my crusade against checkout@v3. GH [complains](https://github.com/stackhpc/stackhpc-release-train/actions/runs/7703813591) otherwise 