### PR TITLE
Convert numeric releases to strings

### DIFF
--- a/ansible/roles/source-repo-sync/tasks/main.yml
+++ b/ansible/roles/source-repo-sync/tasks/main.yml
@@ -17,8 +17,8 @@
       {
         name: '{{ item.key }}',
         releases:
-          '{{ default_releases | difference(item.value.ignored_releases | default([])) |
-          union(item.value.additional_releases | default([])) | sort }}',
+          '{{ default_releases | map("string") | difference(item.value.ignored_releases | default([]) | map("string")) |
+          union(item.value.additional_releases | default([]) | map("string")) | sort }}',
         workflows:
           { default_branch_only: '{{ openstack_workflows.default_branch_only  |
               difference(item.value.workflows.ignored_workflows.default_branch_only | default([])) |


### PR DESCRIPTION
This avoids an issue where numeric release names such as 2023.1 don't
match the stringified release 2023.1, breaking our ignore_releases
rules.
