### PR TITLE
Fix package promotion, update actions for node 20

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -13,7 +13,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: actions/setup-python@v3
+    - uses: actions/setup-python@v4
       with:
         python-version: 3.11.x
         # Cache Python dependencies

--- a/.github/workflows/container-promote-old.yml
+++ b/.github/workflows/container-promote-old.yml
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Setup Release Train & dependencies
       uses: ./.github/actions/setup

--- a/.github/workflows/container-promote.yml
+++ b/.github/workflows/container-promote.yml
@@ -35,7 +35,7 @@ jobs:
         vault-password-file: ${{ env.ANSIBLE_VAULT_PASSWORD_FILE }}
 
     - name: Clone StackHPC Kayobe configuration repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         repository: stackhpc/stackhpc-kayobe-config
         ref: refs/heads/${{ github.event.inputs.kayobe_config_branch }}

--- a/.github/workflows/container-publish.yml
+++ b/.github/workflows/container-publish.yml
@@ -31,25 +31,14 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - name: Preparing Vault password file
-      run: |
-        echo "$ANSIBLE_VAULT_PASSWORD" > "$ANSIBLE_VAULT_PASSWORD_FILE"
-      env:
-        ANSIBLE_VAULT_PASSWORD: ${{ secrets.ANSIBLE_VAULT_PASSWORD }}
-
-    - name: Installing dependencies
-      run: |
-        sudo apt update &&
-        sudo apt install -y python3-venv &&
-        python3 -m venv venv &&
-        source venv/bin/activate &&
-        pip install -U pip && 
-        pip install -r requirements.txt &&
-        ansible-galaxy collection install -r requirements.yml -p ansible/collections
+    - name: Setup Release Train & dependencies
+      uses: ./.github/actions/setup
+      with:
+        vault-password: ${{ secrets.ANSIBLE_VAULT_PASSWORD }}
+        vault-password-file: ${{ env.ANSIBLE_VAULT_PASSWORD_FILE }}
 
     - name: Publish container repositories
       run: |
-        source venv/bin/activate &&
         ansible-playbook -i ansible/inventory \
         ansible/dev-pulp-container-publish.yml \
         -e kolla_container_image_filter="'$FILTER'" \

--- a/.github/workflows/package-promote.yml
+++ b/.github/workflows/package-promote.yml
@@ -48,7 +48,6 @@ jobs:
         if [[ $CHECK_MODE = true ]]; then
           args="$args --check --diff"
         fi
-        source venv/bin/activate &&
         ansible-playbook -i ansible/inventory \
         ansible/dev-pulp-repo-version-query-kayobe.yml \
         ansible/dev-pulp-repo-promote.yml \

--- a/.github/workflows/package-update-kayobe.yml
+++ b/.github/workflows/package-update-kayobe.yml
@@ -61,7 +61,7 @@ jobs:
       # For now, just create an artifact that the user can download.
       - name: Upload pulp-repo-versions.yml artifact
         if: ${{ steps.git-diff.outputs.changed == 'true' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: pulp-repo-versions.yml
           path: stackhpc-kayobe-config/etc/kayobe/pulp-repo-versions.yml


### PR DESCRIPTION
- CI: Remove use of venv from package-promote.yml
- CI: Update GitHub actions versions to those using node 20
- CI: Use setup action in container-publish.yml
