### PR TITLE
Increase package sync timeout

### DIFF
--- a/.github/workflows/package-sync.yml
+++ b/.github/workflows/package-sync.yml
@@ -39,6 +39,7 @@ jobs:
   package-sync-ark:
     name: Sync package repositories in Ark
     runs-on: ubuntu-latest
+    timeout-minutes: 480
     if: inputs.sync_ark
     steps:
 
@@ -71,6 +72,7 @@ jobs:
     name: Sync package repositories in test
     runs-on: arc-release-train-runner
     needs: package-sync-ark
+    timeout-minutes: 480
     if: inputs.sync_test
     steps:
     - name: Checkout


### PR DESCRIPTION
Increasing the package sync timeout.
Recent failure: https://github.com/stackhpc/stackhpc-release-train/actions/runs/8288868930/job/22685647419