### PR TITLE
Enable zed/yoga upstream sync for requirements

### DIFF
--- a/ansible/inventory/group_vars/all/source-repositories
+++ b/ansible/inventory/group_vars/all/source-repositories
@@ -300,8 +300,6 @@ source_repositories:
           dest: ".github/CODEOWNERS"
   requirements:
     ignored_releases:
-        - zed
-        - yoga
         - xena
         - wallaby
         - victoria


### PR DESCRIPTION
Remove Zed and Yoga from the `requirements.ignored_releases` to allow syncing zed and yoga upstream requirements