### PR TITLE
add stackhpc/2023.1 ironic-python-agent

### DIFF
--- a/ansible/inventory/group_vars/all/source-repositories
+++ b/ansible/inventory/group_vars/all/source-repositories
@@ -193,7 +193,6 @@ source_repositories:
           dest: ".github/CODEOWNERS"
     ignored_releases:
       - zed
-      - 2023.1
   ironic-ui:
     ignored_releases:
       - victoria


### PR DESCRIPTION
we're going to need https://review.opendev.org/c/openstack/ironic-python-agent/+/816685 in antelope
for lvm software raid support