### PR TITLE
Remove broken CentOS 8 CI tests

### DIFF
--- a/terraform/github/terraform.tfvars.json
+++ b/terraform/github/terraform.tfvars.json
@@ -346,8 +346,6 @@
         "Tox pep8 with Python 3.8",
         "Tox releasenotes with Python 3.8",
         "Build Kayobe Image / Build kayobe image",
-        "aio (CentOS OVS) / All in one",
-        "aio (CentOS OVN) / All in one",
         "aio (Rocky OVS) / All in one",
         "aio (Rocky OVN) / All in one",
         "aio (Ubuntu OVS) / All in one",


### PR DESCRIPTION
CentOS AIOs are now failing. The benefit they bring is outweighed by the cost of maintenance at this point. This PR removes them from the list of required tests