### PR TITLE
Update branch protection rules for caracal

### DIFF
--- a/docs/usage/source-code-ci.md
+++ b/docs/usage/source-code-ci.md
@@ -27,7 +27,7 @@ The table below contains the different workflows with a description of each and 
 
 OpenStack use [Tox](https://wiki.openstack.org/wiki/Testing) to manage the unit tests and style checks for the various projects they maintain.
 Therefore, when a `pull request` is opened the tox workflow will automatically perform a series of unit tests and linting in order ensure correctness and style guidelines are being met.
-The python environment will depend on the branch pre-Zed, python 3.6 and python 3.8 will be tested. From Zed onward, python 3.8 and python 3.10 will be tested.
+The python environment will depend on the branch pre-Zed, python 3.6 and python 3.8 will be tested. From Zed onward, python 3.8 and python 3.10 will be tested, though only python 3.10 will be required for Caracal.
 This can be controlled within the strategy matrix of the workflow.
 The Python versions should correspond to those used in the supported OS distributions for a particular release.
 The source for the workflow can be found [here](https://github.com/stackhpc/.github/blob/main/.github/workflows/tox.yml).

--- a/terraform/github/branches.tf
+++ b/terraform/github/branches.tf
@@ -100,11 +100,11 @@ resource "github_branch_protection" "kayobe_branch_protection_py_3-6" {
   }
 }
 
-resource "github_branch_protection" "kayobe_branch_protection_py_3-10" {
+resource "github_branch_protection" "kayobe_branch_protection_zed" {
   for_each      = toset(var.repositories["Kayobe"])
   repository_id = data.github_repository.repositories[each.key].node_id
 
-  pattern                         = "stackhpc/[z,2]*"
+  pattern                         = "stackhpc/zed"
   require_conversation_resolution = true
   allows_deletions                = false
   allows_force_pushes             = false
@@ -120,11 +120,80 @@ resource "github_branch_protection" "kayobe_branch_protection_py_3-10" {
   ]
 
   required_status_checks {
-    contexts = lookup(lookup(var.required_status_checks, each.key, {}), "stackhpc/[z,2]*", lookup(var.required_status_checks, each.key, {
+    contexts = lookup(lookup(var.required_status_checks, each.key, {}), "stackhpc/zed", lookup(var.required_status_checks, each.key, {
       "default" : [
         "tox / Tox pep8 with Python 3.10",
         "tox / Tox py3 with Python 3.10",
         "tox / Tox py3 with Python 3.8"
+      ]
+    }).default)
+    strict = false
+  }
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "github_branch_protection" "kayobe_branch_protection_antelope" {
+  for_each      = toset(var.repositories["Kayobe"])
+  repository_id = data.github_repository.repositories[each.key].node_id
+
+  pattern                         = "stackhpc/2023.1"
+  require_conversation_resolution = true
+  allows_deletions                = false
+  allows_force_pushes             = false
+
+  required_pull_request_reviews {
+    dismiss_stale_reviews           = true
+    require_code_owner_reviews      = true
+    required_approving_review_count = 1
+  }
+
+  push_restrictions = [
+    resource.github_team.organisation_teams["Developers"].node_id
+  ]
+
+  required_status_checks {
+    contexts = lookup(lookup(var.required_status_checks, each.key, {}), "stackhpc/2023.1", lookup(var.required_status_checks, each.key, {
+      "default" : [
+        "tox / Tox pep8 with Python 3.10",
+        "tox / Tox py3 with Python 3.10",
+        "tox / Tox py3 with Python 3.8"
+      ]
+    }).default)
+    strict = false
+  }
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "github_branch_protection" "kayobe_branch_protection_caracal" {
+  for_each      = toset(var.repositories["Kayobe"])
+  repository_id = data.github_repository.repositories[each.key].node_id
+
+  pattern                         = "stackhpc/2024.1"
+  require_conversation_resolution = true
+  allows_deletions                = false
+  allows_force_pushes             = false
+
+  required_pull_request_reviews {
+    dismiss_stale_reviews           = true
+    require_code_owner_reviews      = true
+    required_approving_review_count = 1
+  }
+
+  push_restrictions = [
+    resource.github_team.organisation_teams["Developers"].node_id
+  ]
+
+  required_status_checks {
+    contexts = lookup(lookup(var.required_status_checks, each.key, {}), "stackhpc/2024.1", lookup(var.required_status_checks, each.key, {
+      "default" : [
+        "tox / Tox pep8 with Python 3.10",
+        "tox / Tox py3 with Python 3.10"
       ]
     }).default)
     strict = false
@@ -173,11 +242,11 @@ resource "github_branch_protection" "openstack_branch_protection_py_3-6" {
   }
 }
 
-resource "github_branch_protection" "openstack_branch_protection_py_3-10" {
+resource "github_branch_protection" "openstack_branch_protection_zed" {
   for_each      = toset(var.repositories["OpenStack"])
   repository_id = data.github_repository.repositories[each.key].node_id
 
-  pattern                         = "stackhpc/[z,2]*"
+  pattern                         = "stackhpc/zed"
   require_conversation_resolution = true
   allows_deletions                = false
   allows_force_pushes             = false
@@ -193,11 +262,80 @@ resource "github_branch_protection" "openstack_branch_protection_py_3-10" {
   }
 
   required_status_checks {
-    contexts = lookup(lookup(var.required_status_checks, each.key, {}), "stackhpc/[z,2]*", lookup(var.required_status_checks, each.key, {
+    contexts = lookup(lookup(var.required_status_checks, each.key, {}), "stackhpc/zed", lookup(var.required_status_checks, each.key, {
       "default" : [
         "tox / Tox pep8 with Python 3.10",
         "tox / Tox py3 with Python 3.10",
         "tox / Tox py3 with Python 3.8"
+      ]
+    }).default)
+    strict = false
+  }
+
+  lifecycle {
+    prevent_destroy = false
+  }
+}
+
+resource "github_branch_protection" "openstack_branch_protection_antelope" {
+  for_each      = toset(var.repositories["OpenStack"])
+  repository_id = data.github_repository.repositories[each.key].node_id
+
+  pattern                         = "stackhpc/2023.1"
+  require_conversation_resolution = true
+  allows_deletions                = false
+  allows_force_pushes             = false
+
+  push_restrictions = [
+    resource.github_team.organisation_teams["Developers"].node_id
+  ]
+
+  required_pull_request_reviews {
+    dismiss_stale_reviews           = true
+    require_code_owner_reviews      = true
+    required_approving_review_count = 1
+  }
+
+  required_status_checks {
+    contexts = lookup(lookup(var.required_status_checks, each.key, {}), "stackhpc/2023.1", lookup(var.required_status_checks, each.key, {
+      "default" : [
+        "tox / Tox pep8 with Python 3.10",
+        "tox / Tox py3 with Python 3.10",
+        "tox / Tox py3 with Python 3.8"
+      ]
+    }).default)
+    strict = false
+  }
+
+  lifecycle {
+    prevent_destroy = false
+  }
+}
+
+resource "github_branch_protection" "openstack_branch_protection_caracal" {
+  for_each      = toset(var.repositories["OpenStack"])
+  repository_id = data.github_repository.repositories[each.key].node_id
+
+  pattern                         = "stackhpc/2024.1"
+  require_conversation_resolution = true
+  allows_deletions                = false
+  allows_force_pushes             = false
+
+  push_restrictions = [
+    resource.github_team.organisation_teams["Developers"].node_id
+  ]
+
+  required_pull_request_reviews {
+    dismiss_stale_reviews           = true
+    require_code_owner_reviews      = true
+    required_approving_review_count = 1
+  }
+
+  required_status_checks {
+    contexts = lookup(lookup(var.required_status_checks, each.key, {}), "stackhpc/2024.1", lookup(var.required_status_checks, each.key, {
+      "default" : [
+        "tox / Tox pep8 with Python 3.10",
+        "tox / Tox py3 with Python 3.10"
       ]
     }).default)
     strict = false

--- a/terraform/github/import_resources.py
+++ b/terraform/github/import_resources.py
@@ -3,7 +3,7 @@
 """
 Import existing GitHub resources from the `stackhpc` organisation
 so that they maybe managed by Terraform. It shall only import resources
-that are defined within the `terraform.tfvars.json` file nd are currently
+that are defined within the `terraform.tfvars.json` file and are currently
 available on GitHub.
 """
 
@@ -223,9 +223,17 @@ def main() -> None:
             branch_protection_resource = BranchProtection(team_id.name.lower(
             ), {f"{name}:stackhpc/[vwxy]*": name for name in team_repositories}, parsed_args.dry_run, "_py_3-6")
             branch_protection_resource.refresh_resource()
-            # Post-Zed branch protection
+            # Zed branch protection
             branch_protection_resource = BranchProtection(team_id.name.lower(
-            ), {f"{name}:stackhpc/[z,2]*": name for name in team_repositories}, parsed_args.dry_run, "_py_3-10")
+            ), {f"{name}:stackhpc/zed": name for name in team_repositories}, parsed_args.dry_run, "_zed")
+            branch_protection_resource.refresh_resource()
+            # Antelope branch protection
+            branch_protection_resource = BranchProtection(team_id.name.lower(
+            ), {f"{name}:stackhpc/2023.1": name for name in team_repositories}, parsed_args.dry_run, "_antelope")
+            branch_protection_resource.refresh_resource()
+            # Caracal branch protection
+            branch_protection_resource = BranchProtection(team_id.name.lower(
+            ), {f"{name}:stackhpc/2024.1": name for name in team_repositories}, parsed_args.dry_run, "_caracal")
             branch_protection_resource.refresh_resource()
         else:
             branch_protection_resource = BranchProtection(team_id.name.lower(


### PR DESCRIPTION
This PR essentially just removes the python 3.8 requirement for caracal branches.

Github uses [fnmatch](https://docs.python.org/3/library/fnmatch.html) to match against branch names
The matching is very basic. There is no way to match `zed` and `2023.1` but not `2024.1` 

This means that zed/2023.1/2024.1 all have to be split out into different rules