### PR TITLE
Create 2024.1 branch for ovn-octavia-provider

### DIFF
--- a/ansible/inventory/group_vars/all/source-repositories
+++ b/ansible/inventory/group_vars/all/source-repositories
@@ -291,7 +291,6 @@ source_repositories:
       - xena
       - yoga
       - zed
-      - 2024.1
     workflows:
       ignored_workflows:
         elsewhere:


### PR DESCRIPTION
We need stackhpc/2024.1 branch of ovn-octavia-provider to backport https://review.opendev.org/c/openstack/ovn-octavia-provider/+/923196