### PR TITLE
Filter for https mirrors where possible

### DIFF
--- a/ansible/inventory/group_vars/all/package-repos
+++ b/ansible/inventory/group_vars/all/package-repos
@@ -304,7 +304,7 @@ rpm_package_repos:
 
   # EPEL 8 repositories
   - name: Extra Packages for Enterprise Linux 8 - x86_64
-    url: https://mirrors.fedoraproject.org/mirrorlist?repo=epel-8&arch=x86_64&country=NL&infra=stock&content=centos
+    url: https://mirrors.fedoraproject.org/mirrorlist?repo=epel-8&arch=x86_64&country=NL&infra=stock&content=centos&protocol=https
     # mirror_complete fails with:
     # "This repository uses features which are incompatible with 'mirror' sync. Please sync without mirroring enabled"
     sync_policy: mirror_content_only
@@ -312,7 +312,7 @@ rpm_package_repos:
     short_name: epel
     distribution_name: extra-packages-for-enterprise-linux-8-x86_64-
   - name: Extra Packages for Enterprise Linux Modular 8 - x86_64
-    url: https://mirrors.fedoraproject.org/mirrorlist?repo=epel-modular-8&arch=x86_64&country=NL&infra=stock&content=centos
+    url: https://mirrors.fedoraproject.org/mirrorlist?repo=epel-modular-8&arch=x86_64&country=NL&infra=stock&content=centos&protocol=https
     base_path: epel/8/Modular/x86_64/
     short_name: epel_modular
     distribution_name: extra-packages-for-enterprise-linux-modular-8-x86_64-
@@ -547,19 +547,19 @@ rpm_package_repos:
 
   # Base Rocky Linux 9.1 repositories
   - name: Rocky Linux 9.1 - AppStream
-    url: https://mirrors.rockylinux.org/mirrorlist?repo=rocky-AppStream-9.1&arch=x86_64&country=NL
+    url: https://mirrors.rockylinux.org/mirrorlist?repo=rocky-AppStream-9.1&arch=x86_64&country=NL&protocol=https
     base_path: rocky/9.1/AppStream/x86_64/os/
     short_name: rocky_9_1_appstream
     distribution_name: rocky-9.1-appstream-
     sync: false
   - name: Rocky Linux 9.1 - BaseOS
-    url: https://mirrors.rockylinux.org/mirrorlist?repo=rocky-BaseOS-9.1&arch=x86_64&country=NL
+    url: https://mirrors.rockylinux.org/mirrorlist?repo=rocky-BaseOS-9.1&arch=x86_64&country=NL&protocol=https
     base_path: rocky/9.1/BaseOS/x86_64/os/
     short_name: rocky_9_1_baseos
     distribution_name: rocky-9.1-baseos-
     sync: false
   - name: Rocky Linux 9.1 - Extras
-    url: https://mirrors.rockylinux.org/mirrorlist?repo=rocky-extras-9.1&arch=x86_64&country=NL
+    url: https://mirrors.rockylinux.org/mirrorlist?repo=rocky-extras-9.1&arch=x86_64&country=NL&protocol=https
     base_path: rocky/9.1/extras/x86_64/os/
     short_name: rocky_9_1_extras
     distribution_name: rocky-9.1-extras-
@@ -568,13 +568,13 @@ rpm_package_repos:
   # Additional Rocky Linux 9.1 repositories
   # No advanced virt, Ceph or OpenStack
   - name: Rocky Linux 9.1 - CRB
-    url: https://mirrors.rockylinux.org/mirrorlist?repo=rocky-CRB-9.1&arch=x86_64&country=NL
+    url: https://mirrors.rockylinux.org/mirrorlist?repo=rocky-CRB-9.1&arch=x86_64&country=NL&protocol=https
     base_path: rocky/9.1/CRB/x86_64/os/
     short_name: rocky_9_1_crb
     distribution_name: rocky-9.1-crb-
     sync: false
   - name: Rocky Linux 9.1 - HighAvailability
-    url: https://mirrors.rockylinux.org/mirrorlist?repo=rocky-HighAvailability-9.1&arch=x86_64&country=NL
+    url: https://mirrors.rockylinux.org/mirrorlist?repo=rocky-HighAvailability-9.1&arch=x86_64&country=NL&protocol=https
     base_path: rocky/9.1/highavailability/x86_64/os/
     short_name: rocky_9_1_highavailability
     distribution_name: rocky-9.1-highavailability-
@@ -582,19 +582,19 @@ rpm_package_repos:
 
   # Base Rocky Linux 9.2 repositories
   - name: Rocky Linux 9.2 - AppStream
-    url: https://mirrors.rockylinux.org/mirrorlist?repo=rocky-AppStream-9.2&arch=x86_64&country=NL
+    url: https://mirrors.rockylinux.org/mirrorlist?repo=rocky-AppStream-9.2&arch=x86_64&country=NL&protocol=https
     base_path: rocky/9.2/AppStream/x86_64/os/
     short_name: rocky_9_2_appstream
     distribution_name: rocky-9.2-appstream-
     sync: false
   - name: Rocky Linux 9.2 - BaseOS
-    url: https://mirrors.rockylinux.org/mirrorlist?repo=rocky-BaseOS-9.2&arch=x86_64&country=NL
+    url: https://mirrors.rockylinux.org/mirrorlist?repo=rocky-BaseOS-9.2&arch=x86_64&country=NL&protocol=https
     base_path: rocky/9.2/BaseOS/x86_64/os/
     short_name: rocky_9_2_baseos
     distribution_name: rocky-9.2-baseos-
     sync: false
   - name: Rocky Linux 9.2 - Extras
-    url: https://mirrors.rockylinux.org/mirrorlist?repo=rocky-extras-9.2&arch=x86_64&country=NL
+    url: https://mirrors.rockylinux.org/mirrorlist?repo=rocky-extras-9.2&arch=x86_64&country=NL&protocol=https
     base_path: rocky/9.2/extras/x86_64/os/
     short_name: rocky_9_2_extras
     distribution_name: rocky-9.2-extras-
@@ -603,13 +603,13 @@ rpm_package_repos:
   # Additional Rocky Linux 9.2 repositories
   # No advanced virt, Ceph or OpenStack
   - name: Rocky Linux 9.2 - CRB
-    url: https://mirrors.rockylinux.org/mirrorlist?repo=rocky-CRB-9.2&arch=x86_64&country=NL
+    url: https://mirrors.rockylinux.org/mirrorlist?repo=rocky-CRB-9.2&arch=x86_64&country=NL&protocol=https
     base_path: rocky/9.2/CRB/x86_64/os/
     short_name: rocky_9_2_crb
     distribution_name: rocky-9.2-crb-
     sync: false
   - name: Rocky Linux 9.2 - HighAvailability
-    url: https://mirrors.rockylinux.org/mirrorlist?repo=rocky-HighAvailability-9.2&arch=x86_64&country=NL
+    url: https://mirrors.rockylinux.org/mirrorlist?repo=rocky-HighAvailability-9.2&arch=x86_64&country=NL&protocol=https
     base_path: rocky/9.2/highavailability/x86_64/os/
     short_name: rocky_9_2_highavailability
     distribution_name: rocky-9.2-highavailability-
@@ -617,19 +617,19 @@ rpm_package_repos:
 
   # Base Rocky Linux 9.3 repositories
   - name: Rocky Linux 9.3 - AppStream
-    url: https://mirrors.rockylinux.org/mirrorlist?repo=rocky-AppStream-9.3&arch=x86_64&country=NL
+    url: https://mirrors.rockylinux.org/mirrorlist?repo=rocky-AppStream-9.3&arch=x86_64&country=NL&protocol=https
     base_path: rocky/9.3/AppStream/x86_64/os/
     short_name: rocky_9_3_appstream
     distribution_name: rocky-9.3-appstream-
     sync: false
   - name: Rocky Linux 9.3 - BaseOS
-    url: https://mirrors.rockylinux.org/mirrorlist?repo=rocky-BaseOS-9.3&arch=x86_64&country=NL
+    url: https://mirrors.rockylinux.org/mirrorlist?repo=rocky-BaseOS-9.3&arch=x86_64&country=NL&protocol=https
     base_path: rocky/9.3/BaseOS/x86_64/os/
     short_name: rocky_9_3_baseos
     distribution_name: rocky-9.3-baseos-
     sync: false
   - name: Rocky Linux 9.3 - Extras
-    url: https://mirrors.rockylinux.org/mirrorlist?repo=rocky-extras-9.3&arch=x86_64&country=NL
+    url: https://mirrors.rockylinux.org/mirrorlist?repo=rocky-extras-9.3&arch=x86_64&country=NL&protocol=https
     base_path: rocky/9.3/extras/x86_64/os/
     short_name: rocky_9_3_extras
     distribution_name: rocky-9.3-extras-
@@ -638,13 +638,13 @@ rpm_package_repos:
   # Additional Rocky Linux 9.3 repositories
   # No advanced virt, Ceph or OpenStack
   - name: Rocky Linux 9.3 - CRB
-    url: https://mirrors.rockylinux.org/mirrorlist?repo=rocky-CRB-9.3&arch=x86_64&country=NL
+    url: https://mirrors.rockylinux.org/mirrorlist?repo=rocky-CRB-9.3&arch=x86_64&country=NL&protocol=https
     base_path: rocky/9.3/CRB/x86_64/os/
     short_name: rocky_9_3_crb
     distribution_name: rocky-9.3-crb-
     sync: false
   - name: Rocky Linux 9.3 - HighAvailability
-    url: https://mirrors.rockylinux.org/mirrorlist?repo=rocky-HighAvailability-9.3&arch=x86_64&country=NL
+    url: https://mirrors.rockylinux.org/mirrorlist?repo=rocky-HighAvailability-9.3&arch=x86_64&country=NL&protocol=https
     base_path: rocky/9.3/highavailability/x86_64/os/
     short_name: rocky_9_3_highavailability
     distribution_name: rocky-9.3-highavailability-
@@ -652,17 +652,17 @@ rpm_package_repos:
 
   # Base Rocky Linux 9.4 repositories
   - name: Rocky Linux 9.4 - AppStream
-    url: https://mirrors.rockylinux.org/mirrorlist?repo=rocky-AppStream-9.4&arch=x86_64&country=NL
+    url: https://mirrors.rockylinux.org/mirrorlist?repo=rocky-AppStream-9.4&arch=x86_64&country=NL&protocol=https
     base_path: rocky/9.4/AppStream/x86_64/os/
     short_name: rocky_9_4_appstream
     distribution_name: rocky-9.4-appstream-
   - name: Rocky Linux 9.4 - BaseOS
-    url: https://mirrors.rockylinux.org/mirrorlist?repo=rocky-BaseOS-9.4&arch=x86_64&country=NL
+    url: https://mirrors.rockylinux.org/mirrorlist?repo=rocky-BaseOS-9.4&arch=x86_64&country=NL&protocol=https
     base_path: rocky/9.4/BaseOS/x86_64/os/
     short_name: rocky_9_4_baseos
     distribution_name: rocky-9.4-baseos-
   - name: Rocky Linux 9.4 - Extras
-    url: https://mirrors.rockylinux.org/mirrorlist?repo=rocky-extras-9.4&arch=x86_64&country=NL
+    url: https://mirrors.rockylinux.org/mirrorlist?repo=rocky-extras-9.4&arch=x86_64&country=NL&protocol=https
     base_path: rocky/9.4/extras/x86_64/os/
     short_name: rocky_9_4_extras
     distribution_name: rocky-9.4-extras-
@@ -670,17 +670,17 @@ rpm_package_repos:
   # Additional Rocky Linux 9.4 repositories
   # No advanced virt, Ceph or OpenStack
   - name: Rocky Linux 9.4 - CRB
-    url: https://mirrors.rockylinux.org/mirrorlist?repo=rocky-CRB-9.4&arch=x86_64&country=NL
+    url: https://mirrors.rockylinux.org/mirrorlist?repo=rocky-CRB-9.4&arch=x86_64&country=NL&protocol=https
     base_path: rocky/9.4/CRB/x86_64/os/
     short_name: rocky_9_4_crb
     distribution_name: rocky-9.4-crb-
   - name: Rocky Linux 9.4 - HighAvailability
-    url: https://mirrors.rockylinux.org/mirrorlist?repo=rocky-HighAvailability-9.4&arch=x86_64&country=NL
+    url: https://mirrors.rockylinux.org/mirrorlist?repo=rocky-HighAvailability-9.4&arch=x86_64&country=NL&protocol=https
     base_path: rocky/9.4/highavailability/x86_64/os/
     short_name: rocky_9_4_highavailability
     distribution_name: rocky-9.4-highavailability-
   - name: Rocky Linux 9 - SIG Security Common
-    url: https://mirrors.rockylinux.org/mirrorlist?repo=rocky-sig-security-common-9&arch=x86_64&country=NL
+    url: https://mirrors.rockylinux.org/mirrorlist?repo=rocky-sig-security-common-9&arch=x86_64&country=NL&protocol=https
     base_path: rocky/sig/9/security/x86_64/security-common/
     short_name: rocky_9_sig_security_common
     distribution_name: rocky-9-sig-security-common-
@@ -718,7 +718,7 @@ rpm_package_repos:
     distribution_name: centos-stream-9-storage-ceph-reef-
   # EPEL 9 repository
   - name: Extra Packages for Enterprise Linux 9
-    url: https://mirrors.fedoraproject.org/mirrorlist?repo=epel-9&arch=x86_64&country=NL&infra=stock&content=centos
+    url: https://mirrors.fedoraproject.org/mirrorlist?repo=epel-9&arch=x86_64&country=NL&infra=stock&content=centos&protocol=https
     sync_policy: mirror_content_only
     base_path: epel/9/Everything/x86_64/
     short_name: epel_9


### PR DESCRIPTION
Currently a bunch of the mirrors in these mirrorlists are insecure. This change adds another filter to only use https mirrors