### PR TITLE
Run upstream sync cron earlier

### DIFF
--- a/ansible/roles/source-repo-sync/templates/upstream-sync.jinja
+++ b/ansible/roles/source-repo-sync/templates/upstream-sync.jinja
@@ -2,7 +2,7 @@
 name: Upstream Sync
 'on':
   schedule:
-    - cron: "15 8 * * 1"
+    - cron: "15 6 * * 1"
   workflow_dispatch:
 permissions:
   contents: write


### PR DESCRIPTION
The cron time is defined as UTC, so the upstream sync will now run at 08:15 Central European Time during summer.