### PR TITLE
feat: remove `markgoddard` from teams

### DIFF
--- a/terraform/github/terraform.tfvars.json
+++ b/terraform/github/terraform.tfvars.json
@@ -103,7 +103,6 @@
       "privacy": "closed",
       "users": {
         "maintainers": [
-          "markgoddard",
           "oneswig"
         ],
         "members": [
@@ -122,7 +121,6 @@
       "privacy": "closed",
       "users": {
         "maintainers": [
-          "markgoddard",
           "oneswig"
         ],
         "members": [
@@ -175,8 +173,7 @@
       "privacy": "closed",
       "users": {
         "maintainers": [
-          "oneswig",
-          "markgoddard"
+          "oneswig"
         ],
         "members": [
           "Alex-Welsh",
@@ -214,9 +211,7 @@
       "description": "Team responsible for Kayobe development",
       "privacy": "closed",
       "users": {
-        "maintainers": [
-          "markgoddard"
-        ],
+        "maintainers": [],
         "members": [
           "Alex-Welsh",
           "bbezak",
@@ -233,9 +228,7 @@
       "description": "Team responsible for OpenStack development",
       "privacy": "closed",
       "users": {
-        "maintainers": [
-          "markgoddard"
-        ],
+        "maintainers": [],
         "members": [
           "dougszumski",
           "JohnGarbutt",
@@ -271,9 +264,7 @@
       "description": "Team responsible for Release Train development",
       "privacy": "closed",
       "users": {
-        "maintainers": [
-          "markgoddard"
-        ],
+        "maintainers": [],
         "members": [
           "Alex-Welsh",
           "cityofships",
@@ -290,8 +281,7 @@
       "privacy": "closed",
       "users": {
         "maintainers": [
-          "cityofships",
-          "markgoddard"
+          "cityofships"
         ],
         "members": [
           "bbezak",


### PR DESCRIPTION
Remove @markgoddard from all teams within the organisation. This does mean many teams are without a maintainer. Can be resolved here or within follow up PR.