### PR TITLE
Move Grafana to its own sync group

### DIFF
--- a/ansible/inventory/group_vars/all/package-repos
+++ b/ansible/inventory/group_vars/all/package-repos
@@ -213,7 +213,7 @@ rpm_package_repos:
     policy: on_demand
     base_path: grafana/oss/rpm/
     short_name: grafana
-    sync_group: third_party
+    sync_group: grafana
     distribution_name: grafana-
   - name: MariaDB 10.5
     url: https://dlm.mariadb.com/repo/mariadb-server/10.5/yum/rhel/8/x86_64


### PR DESCRIPTION
The Grafana repository often fails to sync due to server side issues. These failures cause the other third party repos to fail.

This change moves grafan to its own sync group so no other syncs are affected.