### PR TITLE
Change Ceph Reef for Debian repo short name

### DIFF
--- a/ansible/inventory/group_vars/all/package-repos
+++ b/ansible/inventory/group_vars/all/package-repos
@@ -150,7 +150,7 @@ deb_package_repos:
     mirror: true
     mode: verbatim
     base_path: ceph/debian-reef/
-    short_name: ceph_reef_ubuntu_jammy
+    short_name: ceph_reef_debian
     sync_group: third_party
     distribution_name: ceph-reef-debian-
 


### PR DESCRIPTION
Instead of 'Ubuntu Jammy', 'Debian' was used when defining this repository.
Changing the ``short_name`` to ``ceph_reef_debian`` for consistency and the jobs relying on names.