### PR TITLE
Enable stackhpc/2024.1 branch for Bifrost

### DIFF
--- a/ansible/inventory/group_vars/all/source-repositories
+++ b/ansible/inventory/group_vars/all/source-repositories
@@ -107,7 +107,6 @@ source_repositories:
       - yoga
       - zed
       - 2023.1
-      - 2024.1
     community_files:
       - codeowners:
           content: "{{ community_files.codeowners.kayobe }}"


### PR DESCRIPTION
Bifrost bug https://bugs.launchpad.net/kayobe/+bug/2072550 is affecting Caracal fresh deployment and blocking hardware inspection.

There is upsteam backport proposed but currently no core-reviewers approval.

We need to temporarily use downstream Bifrost to fix this bug.