### PR TITLE
Stop syncing cinder for zed and yoga

### DIFF
--- a/ansible/inventory/group_vars/all/source-repositories
+++ b/ansible/inventory/group_vars/all/source-repositories
@@ -144,6 +144,8 @@ source_repositories:
       - victoria
       - wallaby
       - xena
+      - yoga
+      - zed
       - 2023.1
       - 2024.1
     community_files:


### PR DESCRIPTION
All patches have been merged upstream.