### PR TITLE
fix: import missing `SMSLAB` branch protection rules

### DIFF
--- a/terraform/github/import_resources.py
+++ b/terraform/github/import_resources.py
@@ -235,6 +235,10 @@ def main() -> None:
             branch_protection_resource = BranchProtection(team_id.name.lower(
             ), {f"{name}:stackhpc/2024.1": name for name in team_repositories}, parsed_args.dry_run, "_caracal")
             branch_protection_resource.refresh_resource()
+        elif team_id == TeamID.SMSLAB:
+            branch_protection_resource = BranchProtection(team_id.name.lower(
+            ), {f"{name}:smslab/[y,z,2]*": name for name in team_repositories}, parsed_args.dry_run)
+            branch_protection_resource.refresh_resource()
         else:
             branch_protection_resource = BranchProtection(team_id.name.lower(
             ), {f"{name}:{default_branches[name]}": name for name in team_repositories}, parsed_args.dry_run)


### PR DESCRIPTION
Branch protection rules for `SMSLAB` were missing. The branch protection import assumes default unless specified otherwise. Since SMSLab uses `smslab/[y,z,2]*` and not the repositories default branch it was failing to import as the rule was non-existent.