### PR TITLE
feat: add `ansible-lint` as required check

### DIFF
--- a/terraform/github/terraform.tfvars.json
+++ b/terraform/github/terraform.tfvars.json
@@ -354,6 +354,10 @@
         "aio (Rocky OVN) / All in one",
         "aio (Ubuntu OVS) / All in one",
         "aio (Ubuntu OVN) / All in one"
+      ],
+      "stackhpc/2024.1": [
+        "Ansible 2.15 lint with Python 3.10",
+        "Ansible 2.16 lint with Python 3.12"
       ]
     },
     "stackhpc-release-train": {


### PR DESCRIPTION
Add the two new `ansible-lint` jobs as required checks for `stackhpc-kayobe-config` for `stackhpc/2024.1` only.