### PR TITLE
Fix SKC branch protection

### DIFF
--- a/terraform/github/terraform.tfvars.json
+++ b/terraform/github/terraform.tfvars.json
@@ -356,6 +356,17 @@
         "aio (Ubuntu OVN) / All in one"
       ],
       "stackhpc/2024.1": [
+        "Tox pep8 with Python 3.10",
+        "Tox releasenotes with Python 3.10",
+        "Tox docs with Python 3.10",
+        "Build Kayobe Image / Build kayobe image",
+        "Check container image tags / Check container image tags",
+        "aio (Rocky 9 OVS) / All in one",
+        "aio (Rocky 9 OVN) / All in one",
+        "aio (Ubuntu Jammy OVS) / All in one",
+        "aio (Ubuntu Jammy OVN) / All in one",
+        "aio upgrade (Rocky 9 OVN) / All in one",
+        "aio upgrade (Ubuntu Jammy OVS) / All in one",
         "Ansible 2.15 lint with Python 3.10",
         "Ansible 2.16 lint with Python 3.12"
       ]


### PR DESCRIPTION
A recent change https://github.com/stackhpc/stackhpc-release-train/pull/364 updated the branch protection rules, accidentally removing the defaults