### PR TITLE
Add ansible-role-os-manila-mount role

### DIFF
--- a/ansible/inventory/group_vars/all/source-repositories
+++ b/ansible/inventory/group_vars/all/source-repositories
@@ -370,6 +370,13 @@ source_repositories:
       - codeowners:
           content: "{{ community_files.codeowners.ansible }}"
           dest: ".github/CODEOWNERS"
+  ansible-role-os-manila-mount:
+    repository_type: "ansible"
+    workflows: "{{ ansible_workflows.role }}"
+    community_files:
+      - codeowners:
+          content: "{{ community_files.codeowners.ansible }}"
+          dest: ".github/CODEOWNERS"
   ansible-role-vxlan:
     repository_type: "ansible"
     workflows: "{{ ansible_workflows.role }}"


### PR DESCRIPTION
The ansible-role-os-manila-mount is at v25.1.1 in this repo.

It exists twice in ansible-galaxy.
[stackhpc.os-manila-mount](https://galaxy.ansible.com/ui/standalone/roles/stackhpc/os-manila-mount/) v20.7.0 - 5 years old
[stackhpc.os_manila_mount](https://galaxy.ansible.com/ui/standalone/roles/stackhpc/os_manila_mount/) v24.1.0 - 1 year old

Let's bring it under release-train?