### PR TITLE
Remove branch protection from SKC master

### DIFF
--- a/terraform/github/terraform.tfvars.json
+++ b/terraform/github/terraform.tfvars.json
@@ -369,7 +369,8 @@
         "aio upgrade (Ubuntu Jammy OVS) / All in one",
         "Ansible 2.15 lint with Python 3.10",
         "Ansible 2.16 lint with Python 3.12"
-      ]
+      ],
+      "stackhpc/master": []
     },
     "stackhpc-release-train": {
       "default": [


### PR DESCRIPTION
It will be a while before CI is up and running on the master branch of SKC, especially the AIO jobs. This change removes all required status so merges are not blocked. Changes still require approval from the kayobe team.