### PR TITLE
Re-add ansible-lint ci to SKC/master

### DIFF
--- a/terraform/github/terraform.tfvars.json
+++ b/terraform/github/terraform.tfvars.json
@@ -370,7 +370,10 @@
         "Ansible 2.15 lint with Python 3.10",
         "Ansible 2.16 lint with Python 3.12"
       ],
-      "stackhpc/master": []
+      "stackhpc/master": [
+        "Ansible 2.15 lint with Python 3.10",
+        "Ansible 2.16 lint with Python 3.12"
+      ]
     },
     "stackhpc-release-train": {
       "default": [


### PR DESCRIPTION
The required CI checks appear to revert to defaults if you specify an empty list. Re-adding lint jobs because they give us an easy override