### PR TITLE
Update ansible-lint CI rule for SKC master

### DIFF
--- a/terraform/github/terraform.tfvars.json
+++ b/terraform/github/terraform.tfvars.json
@@ -371,8 +371,8 @@
         "Ansible 2.16 lint with Python 3.12"
       ],
       "stackhpc/master": [
-        "Ansible 2.15 lint with Python 3.10",
-        "Ansible 2.16 lint with Python 3.12"
+        "Ansible 2.17 lint with Python 3.12",
+        "Ansible 2.16 lint with Python 3.10"
       ]
     },
     "stackhpc-release-train": {


### PR DESCRIPTION
Ansible 2.15 is not supported in the master branch of kayobe, so these jobs must be updated.

See also 
https://github.com/stackhpc/stackhpc-kayobe-config/actions/runs/13117423979/job/36595008077?pr=1487
and
https://github.com/stackhpc/stackhpc-kayobe-config/pull/1487