### PR TITLE
Add proxysql

### DIFF
--- a/ansible/inventory/group_vars/all/kolla
+++ b/ansible/inventory/group_vars/all/kolla
@@ -130,6 +130,7 @@ kolla_container_images:
   - prometheus-openstack-exporter
   - prometheus-server
   - prometheus-v2-server
+  - proxysql
   - rabbitmq
   - rabbitmq-3-12
   - rabbitmq-3-13


### PR DESCRIPTION
The Proxysql container has been enabled by default in Dalmatian, so we should support it here

https://docs.openstack.org/releasenotes/kayobe/2024.2.html#:~:text=Enables%20ProxySQL%20by%20default.%20ProxySQL%20can%20be%20disabled%20by%20setting%20the%20kolla_enable_proxysql%20variable%20to%20false.