### PR TITLE
Switch release train runners back to Leafcloud

### DIFF
--- a/.github/workflows/container-sync.yml
+++ b/.github/workflows/container-sync.yml
@@ -32,7 +32,7 @@ env:
 jobs:
   container-sync:
     name: Sync container repositories
-    runs-on: arc-release-train-runner-sms
+    runs-on: arc-release-train-runner
     timeout-minutes: 720
     steps:
       - name: Checkout

--- a/.github/workflows/package-sync-nightly.yml
+++ b/.github/workflows/package-sync-nightly.yml
@@ -9,7 +9,7 @@ env:
 jobs:
   sync-matrix-build:
     name: Build package matrix of package repo sync jobs
-    runs-on: arc-release-train-runner-sms
+    runs-on: arc-release-train-runner
     outputs:
       matrix: ${{ steps.matrix-build.outputs.matrix }}
     steps:

--- a/.github/workflows/package-sync-version-test-pulp.yml
+++ b/.github/workflows/package-sync-version-test-pulp.yml
@@ -21,7 +21,7 @@ env:
 jobs:
   package-sync-version-test:
     name: Sync specific package repository versions from Ark to Test Pulp
-    runs-on: arc-release-train-runner-sms
+    runs-on: arc-release-train-runner
     steps:
       - name: This workflow does not currently work. Test pulp does not exist.
         run: exit 1

--- a/.github/workflows/package-sync.yml
+++ b/.github/workflows/package-sync.yml
@@ -39,7 +39,7 @@ env:
 jobs:
   package-sync-ark:
     name: Sync package repositories in Ark
-    runs-on: arc-release-train-runner-sms
+    runs-on: arc-release-train-runner
     timeout-minutes: 480
     if: inputs.sync_ark
     steps:
@@ -84,7 +84,7 @@ jobs:
 
   package-sync-test:
     name: Sync package repositories in test
-    runs-on: arc-release-train-runner-sms
+    runs-on: arc-release-train-runner
     needs: package-sync-ark
     timeout-minutes: 480
     if: inputs.sync_test


### PR DESCRIPTION
Recent connectivity issues between Leafcloud and SMS have been impacting CI. This change centralises the nightly sync CI on Leafcloud