### PR TITLE
Bump SKC Ansible version status checks

### DIFF
--- a/terraform/github/terraform.tfvars.json
+++ b/terraform/github/terraform.tfvars.json
@@ -370,8 +370,8 @@
         "Ansible 2.16 lint with Python 3.12"
       ],
       "stackhpc/master": [
-        "Ansible 2.17 lint with Python 3.12",
-        "Ansible 2.16 lint with Python 3.10"
+        "Ansible 2.18 lint with Python 3.12",
+        "Ansible 2.17 lint with Python 3.10"
       ]
     },
     "stackhpc-release-train": {


### PR DESCRIPTION
Ansible deps recently changed in Kayobe. The name of the jobs changed, so we need to update the name here as well. 

See also https://github.com/stackhpc/stackhpc-kayobe-config/pull/1618