### PR TITLE
Mark prometheus-server as buildable

### DIFF
--- a/ansible/inventory/group_vars/all/kolla
+++ b/ansible/inventory/group_vars/all/kolla
@@ -174,7 +174,6 @@ kolla_unbuildable_images:
     - iscsid
     - kibana
     - logstash
-    - prometheus-server
     - prometheus-jiralert
 
 # List of supported base container OS distributions.


### PR DESCRIPTION
The name `prometheus-v2-server` is being replaced with `prometheus-server` when we go to v3 in epoxy, so it is no longer unbuildable.