### PR TITLE
Sync grafana repository content immediately

### DIFF
--- a/ansible/inventory/group_vars/all/package-repos
+++ b/ansible/inventory/group_vars/all/package-repos
@@ -255,10 +255,10 @@ rpm_package_repos:
     short_name: elasticsearch_logstash_kibana_7_x
     sync_group: third_party
     distribution_name: elasticsearch-logstash-kibana-7.x-
-  # Note(piotrp): With repository size of 16G - for now we'll want this on_demand
+  # Note(matta): Sync content immediately as it can be removed from the upstream mirrors
   - name: Grafana
     url: https://rpm.grafana.com
-    policy: on_demand
+    policy: immediate
     base_path: grafana/oss/rpm/
     short_name: grafana
     sync_group: grafana


### PR DESCRIPTION
Grafana RPMs can go missing from the upstream, causing unexpected 404s when we try and download an RPM that our synced metadata says should exist.

Immediately sync RPMs from the upstream Grafana repositories, so that we have a copy in Ark if they are removed from https://rpm.grafana.com.