### PR TITLE
Remove Ubuntu OVS CI checks, require AIO checks for master

### DIFF
--- a/terraform/github/terraform.tfvars.json
+++ b/terraform/github/terraform.tfvars.json
@@ -365,6 +365,15 @@
         "Ansible 2.16 lint with Python 3.12"
       ],
       "stackhpc/master": [
+        "Tox pep8 with Python 3.12",
+        "Tox releasenotes with Python 3.12",
+        "Tox docs with Python 3.12",
+        "Build Kayobe Image / Build kayobe image",
+        "Check container image tags / Check container image tags",
+        "aio (Rocky 9 OVS) / All in one",
+        "aio (Rocky 9 OVN) / All in one",
+        "aio (Ubuntu Noble OVN) / All in one",
+        "aio upgrade (Rocky 9 OVN) / All in one",
         "Ansible 2.18 lint with Python 3.12",
         "Ansible 2.17 lint with Python 3.10"
       ]

--- a/terraform/github/terraform.tfvars.json
+++ b/terraform/github/terraform.tfvars.json
@@ -340,10 +340,8 @@
         "Check container image tags / Check container image tags",
         "aio (Rocky 9 OVS) / All in one",
         "aio (Rocky 9 OVN) / All in one",
-        "aio (Ubuntu Jammy OVS) / All in one",
         "aio (Ubuntu Jammy OVN) / All in one",
-        "aio upgrade (Rocky 9 OVN) / All in one",
-        "aio upgrade (Ubuntu Jammy OVS) / All in one"
+        "aio upgrade (Rocky 9 OVN) / All in one"
       ],
       "stackhpc/[vwxy]*": [
         "Tox pep8 with Python 3.8",
@@ -351,7 +349,6 @@
         "Build Kayobe Image / Build kayobe image",
         "aio (Rocky OVS) / All in one",
         "aio (Rocky OVN) / All in one",
-        "aio (Ubuntu OVS) / All in one",
         "aio (Ubuntu OVN) / All in one"
       ],
       "stackhpc/2024.1": [
@@ -362,10 +359,8 @@
         "Check container image tags / Check container image tags",
         "aio (Rocky 9 OVS) / All in one",
         "aio (Rocky 9 OVN) / All in one",
-        "aio (Ubuntu Jammy OVS) / All in one",
         "aio (Ubuntu Jammy OVN) / All in one",
         "aio upgrade (Rocky 9 OVN) / All in one",
-        "aio upgrade (Ubuntu Jammy OVS) / All in one",
         "Ansible 2.15 lint with Python 3.10",
         "Ansible 2.16 lint with Python 3.12"
       ],


### PR DESCRIPTION
We no longer have an Ubuntu/OVS customers, so we can remove the required status checks (and then disable the CI to save resources)

Master is also at the point where it can run AIOs, so we need to add them as required checks