### PR TITLE
Increase gh label list limit

### DIFF
--- a/ansible/roles/source-repo-sync/tasks/add_label.yml
+++ b/ansible/roles/source-repo-sync/tasks/add_label.yml
@@ -1,7 +1,7 @@
 ---
 - name: Check if required label exists # noqa command-instead-of-shell
   ansible.builtin.shell:
-    cmd: gh label list --json name --jq 'any(.name == "{{ label_name }}")'
+    cmd: gh label list -L 500 --json name --jq 'any(.name == "{{ label_name }}")'
     chdir: "{{ staging_path }}/{{ repository_manifest.name }}"
   changed_when: false
   register: label_exists


### PR DESCRIPTION
When listing labels using the `gh`, there is a default limit of 30. We have exceeded this limit in some places, which can cause the check to fail:
```console
alex@alex-XPS-9315:~/work/skc$ gh label list -L 500 --json name --jq 'any(.name == "stackhpc-ci")'
true
alex@alex-XPS-9315:~/work/skc$ gh label list  --json name --jq 'any(.name == "stackhpc-ci")'
false
```

This change increases the label limit to 500