### PR TITLE
Disable branch protection on ovn-octavia-provider

### DIFF
--- a/terraform/github/terraform.tfvars.json
+++ b/terraform/github/terraform.tfvars.json
@@ -332,6 +332,9 @@
         "Build OpenStack admin guide"
       ]
     },
+    "ovn-octavia-provider": {
+      "default": []
+    },
     "stackhpc-kayobe-config": {
       "default": [
         "Tox pep8 with Python 3.10",


### PR DESCRIPTION
The OVN octavia provider repo has [tox checks disabled](https://github.com/stackhpc/stackhpc-release-train/blob/a68068cd6b6be23f6b4ba1b53721e1d273461e91/ansible/inventory/group_vars/all/source-repositories#L357-L360) but branch protection enabled which means [PRs can never be merged](https://github.com/stackhpc/ovn-octavia-provider/pulls) without admin intervention 