### PR TITLE
Re-enable tox checks on ovn-octavia-provider

### DIFF
--- a/ansible/inventory/group_vars/all/source-repositories
+++ b/ansible/inventory/group_vars/all/source-repositories
@@ -352,10 +352,6 @@ source_repositories:
       - xena
       - yoga
       - zed
-    workflows:
-      ignored_workflows:
-        elsewhere:
-          - tox
     community_files:
       - codeowners:
           content: "{{ community_files.codeowners.openstack }}"

--- a/terraform/github/terraform.tfvars.json
+++ b/terraform/github/terraform.tfvars.json
@@ -335,9 +335,6 @@
         "Build OpenStack admin guide"
       ]
     },
-    "ovn-octavia-provider": {
-      "default": []
-    },
     "stackhpc-kayobe-config": {
       "default": [
         "Tox pep8 with Python 3.10",


### PR DESCRIPTION
Tox checks appear to work [1][2] so we should re-enable them. This also unblocks CI because branch protection _should_ be disabled at the moment but isn't, so nothing is mergable

[1] 2024.1 https://github.com/stackhpc/ovn-octavia-provider/actions/runs/15681036883
[2] 2025.1 https://github.com/stackhpc/ovn-octavia-provider/actions/runs/15680915298