### PR TITLE
Add required status checks for SKC stackhpc/2025.1

### DIFF
--- a/terraform/github/terraform.tfvars.json
+++ b/terraform/github/terraform.tfvars.json
@@ -370,7 +370,19 @@
         "Ansible 2.16 lint with Python 3.12"
       ],
       "stackhpc/2025.1": [
-        "Tox pep8 with Python 3.12"
+        "Tox pep8 with Python 3.12",
+        "Tox releasenotes with Python 3.12",
+        "Tox docs with Python 3.12",
+        "Build Kayobe Image / Build kayobe image",
+        "Check container image tags / Check container image tags",
+        "aio (Rocky 9 OVS) / All in one",
+        "aio (Rocky 9 OVN) / All in one",
+        "aio (Ubuntu Noble OVN) / All in one",
+        "aio upgrade (Rocky 9 OVS) / All in one",
+        "aio upgrade (Rocky 9 OVN) / All in one",
+        "aio upgrade (Ubuntu Jammy to Noble OVN) / All in one",
+        "Ansible 2.18 lint with Python 3.12",
+        "Ansible 2.17 lint with Python 3.10"
       ],
       "stackhpc/master": [
         "Tox pep8 with Python 3.12",


### PR DESCRIPTION
Checks should now all pass consistently, so we should make them mandatory again.

Example CI run: https://github.com/stackhpc/stackhpc-kayobe-config/actions/runs/16141148403