### PR TITLE
Update Caracal SKC required status checks

### DIFF
--- a/terraform/github/terraform.tfvars.json
+++ b/terraform/github/terraform.tfvars.json
@@ -366,6 +366,8 @@
         "aio (Rocky 9 OVN) / All in one",
         "aio (Ubuntu Jammy OVN) / All in one",
         "aio upgrade (Rocky 9 OVN) / All in one",
+        "aio upgrade (Rocky 9 OVS) / All in one",
+        "aio upgrade (Ubuntu Jammy OVN) / All in one",
         "Ansible 2.15 lint with Python 3.10",
         "Ansible 2.16 lint with Python 3.12"
       ],


### PR DESCRIPTION
CI was changed in https://github.com/stackhpc/stackhpc-kayobe-config/pull/1641

The old checks were removed in https://github.com/stackhpc/stackhpc-release-train/pull/401 but new ones were not added 