### PR TITLE
Requre a third pair of eyes in Kayobe reviews

### DIFF
--- a/terraform/github/branches.tf
+++ b/terraform/github/branches.tf
@@ -181,7 +181,7 @@ resource "github_branch_protection" "kayobe_branch_protection_caracal" {
   required_pull_request_reviews {
     dismiss_stale_reviews           = true
     require_code_owner_reviews      = true
-    required_approving_review_count = 1
+    required_approving_review_count = 2
   }
 
   push_restrictions = [
@@ -215,7 +215,7 @@ resource "github_branch_protection" "kayobe_branch_protection_epoxy" {
   required_pull_request_reviews {
     dismiss_stale_reviews           = true
     require_code_owner_reviews      = true
-    required_approving_review_count = 1
+    required_approving_review_count = 2
   }
 
   push_restrictions = [
@@ -251,7 +251,7 @@ resource "github_branch_protection" "kayobe_branch_protection_master" {
   required_pull_request_reviews {
     dismiss_stale_reviews           = true
     require_code_owner_reviews      = true
-    required_approving_review_count = 1
+    required_approving_review_count = 2
   }
 
   push_restrictions = [


### PR DESCRIPTION
Proposing this change so it might help in catching more issues before and not after the changes are merged. The main target being s-k-c repository, it currently shares protection rules with 'Kayobe' category repos. Could create a separate dedicated rule if we wanted.