### PR TITLE
Add Keystone upstream sync

### DIFF
--- a/ansible/inventory/group_vars/all/source-repositories
+++ b/ansible/inventory/group_vars/all/source-repositories
@@ -256,6 +256,18 @@ source_repositories:
       - codeowners:
           content: "{{ community_files.codeowners.openstack }}"
           dest: ".github/CODEOWNERS"
+  keystone:
+    ignored_releases:
+      - victoria
+      - wallaby
+      - xena
+      - zed
+      - 2023.1
+      - 2024.1
+    community_files:
+      - codeowners:
+          content: "{{ community_files.codeowners.openstack }}"
+          dest: ".github/CODEOWNERS"
   magnum:
     ignored_releases:
       - victoria


### PR DESCRIPTION
Until [1] and [2] are merged, we need to be able to build keystone from downstream source with [1] and [2] applied.

[1] https://review.opendev.org/c/openstack/keystone/+/957547
[2] https://review.opendev.org/c/openstack/keystone/+/956549