### PR TITLE
Remove upgrade flag from terraform init

### DIFF
--- a/.github/workflows/terraform-github.yml
+++ b/.github/workflows/terraform-github.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Terraform Init
         id: init
-        run: terraform init -upgrade
+        run: terraform init
 
       - name: Terraform Validate
         id: validate


### PR DESCRIPTION
This is not required now that we have merged the provider version bump.