### PR TITLE
Allow docs publish to write repo contents

### DIFF
--- a/.github/workflows/docs-publish.yml
+++ b/.github/workflows/docs-publish.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           python-version: 3.x
       - run: pip install -r docs-requirements.txt
-      - run: mkdocs gh-deploy --force       
+      - run: mkdocs gh-deploy --force
 
       - name: Send message to Slack via Workflow Builder
         uses: ./.github/actions/slack-alert

--- a/.github/workflows/docs-publish.yml
+++ b/.github/workflows/docs-publish.yml
@@ -6,6 +6,8 @@ on:
       - main
 jobs:
   docs-publish:
+    permissions:
+      contents: write
     name: Publish documentation
     runs-on: ubuntu-latest
     steps:
@@ -14,7 +16,7 @@ jobs:
         with:
           python-version: 3.x
       - run: pip install -r docs-requirements.txt
-      - run: mkdocs gh-deploy --force
+      - run: mkdocs gh-deploy --force       
 
       - name: Send message to Slack via Workflow Builder
         uses: ./.github/actions/slack-alert


### PR DESCRIPTION
Following a change in default permissions for GITHUB_TOKEN, explicitly request repo contents write permissions for the docs publish job.