### PR TITLE
Disable jammy-noble upgrade status check in SKC 2025.1

### DIFF
--- a/terraform/github/terraform.tfvars.json
+++ b/terraform/github/terraform.tfvars.json
@@ -388,7 +388,6 @@
         "aio (Ubuntu Noble OVN) / All in one",
         "aio upgrade (Rocky 9 OVS) / All in one",
         "aio upgrade (Rocky 9 OVN) / All in one",
-        "aio upgrade (Ubuntu Jammy to Noble OVN) / All in one",
         "Ansible 2.18 lint with Python 3.12",
         "Ansible 2.17 lint with Python 3.10"
       ],


### PR DESCRIPTION
The check is consistently failing at the moment due to issues with ark. This change removes it as a required status check. We will re-enable it in the future when it's more stable