### PR TITLE
Add RL10 AIOs as required checks in SKC CI

### DIFF
--- a/terraform/github/terraform.tfvars.json
+++ b/terraform/github/terraform.tfvars.json
@@ -388,6 +388,8 @@
         "aio (Ubuntu Noble OVN) / All in one",
         "aio upgrade (Rocky 9 OVS) / All in one",
         "aio upgrade (Rocky 9 OVN) / All in one",
+        "aio (Rocky 10 OVS) / All in one",
+        "aio (Rocky 10 OVN) / All in one",
         "Ansible 2.18 lint with Python 3.12",
         "Ansible 2.17 lint with Python 3.10"
       ],


### PR DESCRIPTION
RL10 AIOs have recently been added to SKC CI, this change makes them required status checks