### PR TITLE
Invert ignored_releases

### DIFF
--- a/ansible/inventory/group_vars/all/source-repositories
+++ b/ansible/inventory/group_vars/all/source-repositories
@@ -2,7 +2,7 @@
 # Dictionary acting as a `manifest` of openstack and ansible repositories
 # containing a list of workflows and community files required by a given
 # repository.
-default_releases:
+maintained_releases:
   - "master"
   - "2026.1"
   - "2025.1"
@@ -50,11 +50,27 @@ source_repositories:
           content: "{{ community_files.codeowners.kayobe }}"
           dest: ".github/CODEOWNERS"
   kolla:
+    synced_releases:
+      - "master"
+      - "2026.1"
+      - "2025.1"
+      - "2024.1"
+      - "2023.1"
+      - zed
+      - yoga
     community_files:
       - codeowners:
           content: "{{ community_files.codeowners.kayobe }}"
           dest: ".github/CODEOWNERS"
   kayobe:
+    synced_releases:
+      - "master"
+      - "2026.1"
+      - "2025.1"
+      - "2024.1"
+      - "2023.1"
+      - zed
+      - yoga
     community_files:
       - codeowners:
           content: "{{ community_files.codeowners.kayobe }}"
@@ -67,6 +83,14 @@ source_repositories:
           content: "{{ community_files.codeowners.kayobe }}"
           dest: ".github/CODEOWNERS"
   kolla-ansible:
+    synced_releases:
+      - "master"
+      - "2026.1"
+      - "2025.1"
+      - "2024.1"
+      - "2023.1"
+      - zed
+      - yoga
     community_files:
       - codeowners:
           content: "{{ community_files.codeowners.kayobe }}"
@@ -79,6 +103,14 @@ source_repositories:
           content: "{{ community_files.codeowners.kayobe }}"
           dest: ".github/CODEOWNERS"
   stackhpc-kayobe-config:
+    synced_releases:
+      - "master"
+      - "2026.1"
+      - "2025.1"
+      - "2024.1"
+      - "2023.1"
+      - zed
+      - yoga
     workflows:
       ignored_workflows:
         elsewhere:
@@ -98,43 +130,35 @@ source_repositories:
           dest: ".github/CODEOWNERS"
   # OpenStack team
   bifrost:
-    ignored_releases:
-      - yoga
-      - zed
-      - 2023.1
-      - master
+    synced_releases:
+      - "2026.1"
+      - "2025.1"
+      - "2024.1"
     community_files:
       - codeowners:
           content: "{{ community_files.codeowners.openstack }}"
           dest: ".github/CODEOWNERS"
   barbican:
-    ignored_releases:
-      - yoga
-      - zed
-      - 2023.1
-      - 2024.1
-      - 2025.1
-      - 2026.1
-      - master
+    synced_releases: []
     community_files:
       - codeowners:
           content: "{{ community_files.codeowners.openstack }}"
           dest: ".github/CODEOWNERS"
   blazar:
-    ignored_releases:
-      - yoga
-      - zed
-      - 2023.1
-      - 2024.1
+    synced_releases:
+      - "master"
+      - "2026.1"
+      - "2025.1"
     community_files:
       - codeowners:
           content: "{{ community_files.codeowners.openstack }}"
           dest: ".github/CODEOWNERS"
   cinder:
-    ignored_releases:
-      - yoga
-      - zed
-      - master
+    synced_releases:
+      - "2026.1"
+      - "2025.1"
+      - "2024.1"
+      - "2023.1"
     community_files:
       - codeowners:
           content: "{{ community_files.codeowners.openstack }}"
@@ -144,23 +168,19 @@ source_repositories:
       - codeowners:
           content: "{{ community_files.codeowners.openstack }}"
           dest: ".github/CODEOWNERS"
-    ignored_releases:
-      - 2025.1
-      - 2026.1
-      - master
+    synced_releases:
+      - "2024.1"
+      - "2023.1"
+      - zed
+      - yoga
   cloudkitty-dashboard:
     community_files:
       - codeowners:
           content: "{{ community_files.codeowners.openstack }}"
           dest: ".github/CODEOWNERS"
   designate-dashboard:
-    ignored_releases:
-      - zed
-      - 2023.1
-      - 2024.1
-      - 2025.1
-      - 2026.1
-      - master
+    synced_releases:
+      - yoga
     workflows:
       ignored_workflows:
         elsewhere:
@@ -170,34 +190,25 @@ source_repositories:
           content: "{{ community_files.codeowners.openstack }}"
           dest: ".github/CODEOWNERS"
   glance:
-    ignored_releases:
-      - 2023.1
-      - 2025.1
-      - 2026.1
-      - master
+    synced_releases:
+      - "2024.1"
+      - zed
+      - yoga
     community_files:
       - codeowners:
           content: "{{ community_files.codeowners.openstack }}"
           dest: ".github/CODEOWNERS"
   glance_store:
-    ignored_releases:
-      - yoga
-      - zed
-      - 2023.1
-      - 2025.1
-      - 2026.1
-      - master
+    synced_releases:
+      - "2024.1"
     community_files:
       - codeowners:
           content: "{{ community_files.codeowners.openstack }}"
           dest: ".github/CODEOWNERS"
   horizon:
-    ignored_releases:
-      - zed
-      - 2024.1
-      - 2025.1
-      - 2026.1
-      - master
+    synced_releases:
+      - "2023.1"
+      - yoga
     workflows:
       ignored_workflows:
         elsewhere:
@@ -207,12 +218,9 @@ source_repositories:
           content: "{{ community_files.codeowners.openstack }}"
           dest: ".github/CODEOWNERS"
   ironic:
-    ignored_releases:
-      - zed
-      - 2023.1
-      - 2024.1
-      - 2026.1
-      - master
+    synced_releases:
+      - "2025.1"
+      - yoga
     community_files:
       - codeowners:
           content: "{{ community_files.codeowners.openstack }}"
@@ -222,20 +230,12 @@ source_repositories:
       - codeowners:
           content: "{{ community_files.codeowners.openstack }}"
           dest: ".github/CODEOWNERS"
-    ignored_releases:
-      - zed
-      - 2024.1
-      - 2025.1
-      - 2026.1
-      - master
+    synced_releases:
+      - "2023.1"
+      - yoga
   ironic-ui:
-    ignored_releases:
-      - zed
-      - 2023.1
-      - 2024.1
-      - 2025.1
-      - 2026.1
-      - master
+    synced_releases:
+      - yoga
     workflows:
       ignored_workflows:
         elsewhere:
@@ -245,11 +245,10 @@ source_repositories:
           content: "{{ community_files.codeowners.openstack }}"
           dest: ".github/CODEOWNERS"
   keystone:
-    ignored_releases:
-      - zed
-      - 2025.1
-      - 2026.1
-      - master
+    synced_releases:
+      - "2024.1"
+      - "2023.1"
+      - "yoga"
     community_files:
       - codeowners:
           content: "{{ community_files.codeowners.openstack }}"
@@ -260,13 +259,8 @@ source_repositories:
           content: "{{ community_files.codeowners.openstack }}"
           dest: ".github/CODEOWNERS"
   magnum-ui:
-    ignored_releases:
-      - zed
-      - 2023.1
-      - 2024.1
-      - 2025.1
-      - 2026.1
-      - master
+    synced_releases:
+      - yoga
     workflows:
       ignored_workflows:
         elsewhere:
@@ -276,26 +270,33 @@ source_repositories:
           content: "{{ community_files.codeowners.openstack }}"
           dest: ".github/CODEOWNERS"
   manila:
-    ignored_releases:
-      - yoga
-      - zed
-      - 2023.1
-      - 2024.1
-      - master
+    synced_releases:
+      - "2026.1"
+      - "2025.1"
     community_files:
       - codeowners:
           content: "{{ community_files.codeowners.openstack }}"
           dest: ".github/CODEOWNERS"
   networking-generic-switch:
-    ignored_releases:
-      - master
+    synced_releases:
+      - "2026.1"
+      - "2025.1"
+      - "2024.1"
+      - "2023.1"
+      - zed
+      - yoga
     community_files:
       - codeowners:
           content: "{{ community_files.codeowners.openstack }}"
           dest: ".github/CODEOWNERS"
   neutron:
-    ignored_releases:
-      - 2024.1
+    synced_releases:
+      - "master"
+      - "2026.1"
+      - "2025.1"
+      - "2023.1"
+      - zed
+      - yoga
     workflows:
       ignored_workflows:
         elsewhere:
@@ -305,29 +306,30 @@ source_repositories:
           content: "{{ community_files.codeowners.openstack }}"
           dest: ".github/CODEOWNERS"
   nova:
-    ignored_releases:
-      - master
+    synced_releases:
+      - "2026.1"
+      - "2025.1"
+      - "2024.1"
+      - "2023.1"
+      - zed
+      - yoga
     community_files:
       - codeowners:
           content: "{{ community_files.codeowners.openstack }}"
           dest: ".github/CODEOWNERS"
   octavia:
-    ignored_releases:
-      - yoga
-      - zed
-      - master
+    synced_releases:
+      - "2026.1"
+      - "2025.1"
+      - "2024.1"
+      - "2023.1"
     community_files:
       - codeowners:
           content: "{{ community_files.codeowners.openstack }}"
           dest: ".github/CODEOWNERS"
   octavia-dashboard:
-    ignored_releases:
-      - zed
-      - 2023.1
-      - 2024.1
-      - 2025.1
-      - 2026.1
-      - master
+    synced_releases:
+      - yoga
     workflows:
       ignored_workflows:
         elsewhere:
@@ -337,14 +339,7 @@ source_repositories:
           content: "{{ community_files.codeowners.openstack }}"
           dest: ".github/CODEOWNERS"
   ovn-octavia-provider:
-    ignored_releases:
-      - yoga
-      - zed
-      - 2023.1
-      - 2024.1
-      - 2025.1
-      - 2026.1
-      - master
+    synced_releases: []
     community_files:
       - codeowners:
           content: "{{ community_files.codeowners.openstack }}"
@@ -357,6 +352,14 @@ source_repositories:
           content: "{{ community_files.codeowners.openstack }}"
           dest: ".github/CODEOWNERS"
   requirements:
+    synced_releases:
+      - "master"
+      - "2026.1"
+      - "2025.1"
+      - "2024.1"
+      - "2023.1"
+      - zed
+      - yoga
     community_files:
       - codeowners:
           content: "{{ community_files.codeowners.openstack }}"

--- a/ansible/roles/source-repo-sync/defaults/main.yml
+++ b/ansible/roles/source-repo-sync/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 owner: stackhpc
 staging_path: ~/.repo-staging
-default_releases: []
+maintained_releases: []
 openstack_workflows:
   default_branch_only: []
   elsewhere: []

--- a/ansible/roles/source-repo-sync/tasks/main.yml
+++ b/ansible/roles/source-repo-sync/tasks/main.yml
@@ -15,7 +15,7 @@
   vars:
     repository_manifest:
       name: "{{ item.key }}"
-      releases: '{{ default_releases | map("string") | difference(item.value.ignored_releases | default([]) | map("string")) | union(item.value.additional_releases
+      releases: '{{ maintained_releases | map("string") | intersect(item.value.synced_releases | default([]) | map("string")) | union(item.value.additional_releases
         | default([]) | map("string")) | sort }}'
       workflows:
         default_branch_only: "{{ openstack_workflows.default_branch_only | difference(item.value.workflows.ignored_workflows.default_branch_only | default([])) |

--- a/docs/usage/source-code-ci.md
+++ b/docs/usage/source-code-ci.md
@@ -81,10 +81,10 @@ The motivation behind this is to have single-source of truth and free up develop
 
 !!! info "Source Repositories Vars"
 
-    * **default_releases**: list of OpenStack release series currently supported by StackHPC and used within the workflows
+    * **maintained_releases**: list of OpenStack release series currently supported by StackHPC and used within the workflows
     * **openstack_workflows**: dictionary of OpenStack specific workflows as mentioned above
         * default_branch_only: list of workflows that will only exist on the `default branch` **(master/main)**
-        * elsewhere: list of workflows that will be placed on other branches such as `stackhpc/xena` see `default_releases`
+        * elsewhere: list of workflows that will be placed on other branches such as `stackhpc/xena` see `maintained_releases`
     * **ansible_workflows**: dictionary that contains either the type of Ansible `collection` or `role`
         * collection: list of workflows specific to Ansible collections
         * role: list of workflows specific to Ansible roles
@@ -97,7 +97,7 @@ The motivation behind this is to have single-source of truth and free up develop
 
     ```yaml
     ---
-    default_releases:
+    maintained_releases:
       - xena
       - wallaby
       - victoria
@@ -125,7 +125,7 @@ The motivation behind this is to have single-source of truth and free up develop
               content: '{{ community_files.codeowners.kayobe_codeowners }}'
               dest: '.github/CODEOWNERS'
       barbican:
-        ignored_releases:
+        synced_releases:
           - victoria
           - xena
       stackhpc-inspector-plugins:
@@ -151,12 +151,12 @@ Please review the `Source Repositories Vars` for a description of the variables 
 To add new repositories to be handled by this playbook you can edit [source-repositories](https://github.com/stackhpc/stackhpc-release-train/blob/main/ansible/inventory/group_vars/all/source-repositories).
 Identify the `source_repositories` dictionary and insert your new repository.
 For example the below code snippet will add neutron to the `source repo sync` all default workflows and community files.
-Also all release series will be ignored except `yoga`.
+Also all release series will be synced except `yoga`.
 
 ```yaml
 source_repositories:
   neutron:
-    ignored_releases:
+    synced_releases:
       - xena
       - wallaby
       - victoria
@@ -172,27 +172,48 @@ source_repositories:
 
 #### Changing the release series
 
-To change the release series for all OpenStack repositories this can be achived by editing the `default_releases` variable.
-For example if you wanted to remove victoria and add support for yoga.
-Once this change has been merged into the `main` branch it shall perform a series of pull requests updating the workflows across all listed repositories.
+To add a new release series, it must be added to the `maintained_releases` variable globally, and then `synced_releases` for each required branch.
+For example if you wanted to remove victoria and add support for yoga:
 
 !!! note "ansible/inventory/group_vars/all/source-repositories"
 
     ```yaml
     ---
-    default_releases:
+    maintained_releases:
       - xena
       - wallaby
       - victoria
+    source_repositories:
+      neutron:
+        synced_releases:
+          - xena
+          - wallaby
+          - victoria
+        community_files:
+          - codeowners:
+              content: "{{ community_files.codeowners.openstack }}"
+              dest: ".github/CODEOWNERS"
     ```
 
     ```yaml
     ---
-    default_releases:
+    maintained_releases:
       - yoga
       - xena
       - wallaby
+    source_repositories:
+      neutron:
+        synced_releases:
+          - yoga
+          - xena
+          - wallaby
+        community_files:
+          - codeowners:
+              content: "{{ community_files.codeowners.openstack }}"
+              dest: ".github/CODEOWNERS"
+
     ```
+
 
 #### Adding new workflows
 

--- a/scripts/validate-source-repos.py
+++ b/scripts/validate-source-repos.py
@@ -15,8 +15,8 @@ def read_repos_data():
               'r') as file:
         data = yaml.safe_load(file)
         ansible_repositories = data['source_repositories']
-
-    return terraform_repositories, ansible_repositories
+        maintained_releases = data['maintained_releases']
+    return terraform_repositories, ansible_repositories, maintained_releases
 
 
 def get_repos_diff(tf_repos, ans_repos):
@@ -65,8 +65,18 @@ def get_mismatched_repos(tf_repos, ans_repos, repos_missing):
     return list(set(mismatched_repos).difference(set(repos_missing)))
 
 
+def validate_source_repositories(source_repos, maintained_releases):
+    issues = []
+    maintained_set = {str(r) for r in maintained_releases}
+    for reponame, repodata in source_repos.items():
+        synced_releases = [str(r) for r in repodata.get('synced_releases', [])]
+        invalid_releases = set(synced_releases) - maintained_set
+        if invalid_releases:
+            issues.append(f'Repo "{reponame}" is trying to sync releases that are not maintained: {sorted(invalid_releases)}')
+    return issues
+
 def main():
-    terraform_repos, ansible_repos = read_repos_data()
+    terraform_repos, ansible_repos, maintained_releases = read_repos_data()
 
     repos_missing = get_repos_diff(terraform_repos, ansible_repos)
 
@@ -80,7 +90,13 @@ def main():
           'the Ansible source-repositories and the Terraform tfvars: '
           f'{mismatched_repos}')
 
-    return len(repos_missing) > 0 or len(mismatched_repos) > 0
+    source_repos_issues = validate_source_repositories(ansible_repos, maintained_releases)
+    for issue in source_repos_issues:
+        print(issue)
+
+    if repos_missing or mismatched_repos or source_repos_issues:
+        return 1
+    return 0
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Instead of assuming all branches of a repo are synced, it makes more sense to assume they are ignored, and specify the ones we want to sync.

Added a CI test to make sure all synced_releases exist in maintained_releases