### PR TITLE
Remove branch protection for vwx releases

### DIFF
--- a/terraform/github/branches.tf
+++ b/terraform/github/branches.tf
@@ -104,11 +104,7 @@ resource "github_branch_protection" "kayobe_branch_protection_py_3-6" {
   for_each      = toset(var.repositories["Kayobe"])
   repository_id = data.github_repository.repositories[each.key].node_id
 
-  # NOTE(Alex-Welsh): The pattern here is not ideal but it is difficult to
-  # achieve more precision with the matching tools that GitHub provides.
-  # https://stackoverflow.com/questions/53135414/how-to-apply-one-github-branch-rule-to-multiple-branches
-  # Remember to update import_resources.py!
-  pattern                         = "stackhpc/[vwxy]*"
+  pattern                         = "stackhpc/yoga"
   require_conversation_resolution = true
   allows_deletions                = false
   allows_force_pushes             = false
@@ -128,7 +124,7 @@ resource "github_branch_protection" "kayobe_branch_protection_py_3-6" {
   }
 
   required_status_checks {
-    contexts = lookup(lookup(var.required_status_checks, each.key, {}), "stackhpc/[vwxy]*", lookup(var.required_status_checks, each.key, {
+    contexts = lookup(lookup(var.required_status_checks, each.key, {}), "stackhpc/yoga", lookup(var.required_status_checks, each.key, {
       "default" : [
         "tox / Tox pep8 with Python 3.8",
         "tox / Tox py3 with Python 3.8"
@@ -377,11 +373,7 @@ resource "github_branch_protection" "openstack_branch_protection_py_3-6" {
   for_each      = toset(var.repositories["OpenStack"])
   repository_id = data.github_repository.repositories[each.key].node_id
 
-  # NOTE(Alex-Welsh): The pattern here is not ideal but it is difficult to
-  # achieve more precision with the matching tools that GitHub provides.
-  # https://stackoverflow.com/questions/53135414/how-to-apply-one-github-branch-rule-to-multiple-branches
-  # Remember to update import_resources.py!
-  pattern                         = "stackhpc/[vwxy]*"
+  pattern                         = "stackhpc/yoga"
   require_conversation_resolution = true
   allows_deletions                = false
   allows_force_pushes             = false
@@ -401,7 +393,7 @@ resource "github_branch_protection" "openstack_branch_protection_py_3-6" {
   }
 
   required_status_checks {
-    contexts = lookup(lookup(var.required_status_checks, each.key, {}), "stackhpc/[vwxy]*", lookup(var.required_status_checks, each.key, {
+    contexts = lookup(lookup(var.required_status_checks, each.key, {}), "stackhpc/yoga", lookup(var.required_status_checks, each.key, {
       "default" : [
         "tox / Tox pep8 with Python 3.8",
         "tox / Tox py3 with Python 3.8"

--- a/terraform/github/import_resources.py
+++ b/terraform/github/import_resources.py
@@ -220,7 +220,7 @@ def main() -> None:
         if team_id == TeamID.KAYOBE or team_id == TeamID.OPENSTACK:
             # Pre-Zed branch protection
             branch_protection_resource = BranchProtection(team_id.name.lower(
-            ), {f"{name}:stackhpc/[vwxy]*": name for name in team_repositories}, parsed_args.dry_run, "_py_3-6")
+            ), {f"{name}:stackhpc/yoga": name for name in team_repositories}, parsed_args.dry_run, "_py_3-6")
             branch_protection_resource.refresh_resource()
             # Zed branch protection
             branch_protection_resource = BranchProtection(team_id.name.lower(

--- a/terraform/github/terraform.tfvars.json
+++ b/terraform/github/terraform.tfvars.json
@@ -361,7 +361,7 @@
         "aio (Ubuntu Jammy OVN) / All in one",
         "aio upgrade (Rocky 9 OVN) / All in one"
       ],
-      "stackhpc/[vwxy]*": [
+      "stackhpc/yoga": [
         "Tox pep8 with Python 3.8",
         "Tox releasenotes with Python 3.8",
         "Build Kayobe Image / Build kayobe image",


### PR DESCRIPTION
This change adapts our old branch protection rules - matching stackhpc/[vwxy]* to instead only match stackhpc/yoga for two reasons:

1. Older releases (V/W/X) are no longer supported
2. branch protection rules with wildcard matching regularly breaks our automation. For example, stackhpc/yoga-community files matches the existing rules, and is a common branch name for our automation, which can then no longer be deleted. This is a common occurance when re-creating an existing automated PR.