### PR TITLE
Trim SKC 2026.1 required checks while it is in development

### DIFF
--- a/terraform/github/terraform.tfvars.json
+++ b/terraform/github/terraform.tfvars.json
@@ -400,6 +400,11 @@
         "Ansible 2.18 lint with Python 3.12",
         "Ansible 2.17 lint with Python 3.10"
       ],
+      "stackhpc/2026.1": [
+        "Tox pep8 with Python 3.12",
+        "Tox releasenotes with Python 3.12",
+        "Tox docs with Python 3.12"
+      ],
       "stackhpc/master": [
         "Tox pep8 with Python 3.12",
         "Tox releasenotes with Python 3.12",


### PR DESCRIPTION
Removing most required checks for SKC for now. We must have something (empty list will just revert back to the defaults), so I'm keeping tox Python 3.12 checks, which should remain relevant