### PR TITLE
Stop syncing 2026.1 branches where not needed

### DIFF
--- a/ansible/inventory/group_vars/all/source-repositories
+++ b/ansible/inventory/group_vars/all/source-repositories
@@ -155,7 +155,6 @@ source_repositories:
           dest: ".github/CODEOWNERS"
   cinder:
     synced_releases:
-      - "2026.1"
       - "2025.1"
       - "2024.1"
       - "2023.1"
@@ -174,6 +173,14 @@ source_repositories:
       - zed
       - yoga
   cloudkitty-dashboard:
+    synced_releases:
+        - "master"
+        - "2026.1"
+        - "2025.1"
+        - "2024.1"
+        - "2023.1"
+        - zed
+        - yoga
     community_files:
       - codeowners:
           content: "{{ community_files.codeowners.openstack }}"
@@ -254,6 +261,12 @@ source_repositories:
           content: "{{ community_files.codeowners.openstack }}"
           dest: ".github/CODEOWNERS"
   magnum:
+    synced_releases:
+        - "2025.1"
+        - "2024.1"
+        - "2023.1"
+        - zed
+        - yoga
     community_files:
       - codeowners:
           content: "{{ community_files.codeowners.openstack }}"
@@ -279,7 +292,6 @@ source_repositories:
           dest: ".github/CODEOWNERS"
   networking-generic-switch:
     synced_releases:
-      - "2026.1"
       - "2025.1"
       - "2024.1"
       - "2023.1"
@@ -319,7 +331,6 @@ source_repositories:
           dest: ".github/CODEOWNERS"
   octavia:
     synced_releases:
-      - "2026.1"
       - "2025.1"
       - "2024.1"
       - "2023.1"


### PR DESCRIPTION
Also includes a sneaky fix for a few repos which accidentally stopped syncing after https://github.com/stackhpc/stackhpc-release-train/pull/524 merged

Kolla Ansible and Kolla are also not required any more, but it makes sense to keep using them because it would be more effort to switch back to the upstream forks now