### PR TITLE
Add package repos for 2026.1 kolla container image builds

### DIFF
--- a/ansible/inventory/group_vars/all/deb-package-repos
+++ b/ansible/inventory/group_vars/all/deb-package-repos
@@ -264,6 +264,28 @@ deb_package_repos:
     short_name: ubuntu_noble_proxysql
     sync_group: third_party
     distribution_name: ubuntu-noble-proxysql-
+  # Fluentd v6 for Ubuntu Noble
+  - name: Fluentd - Ubuntu Noble
+    url: https://fluentd.cdn.cncf.io/lts/6/ubuntu/noble
+    policy: immediate
+    architectures: amd64
+    distributions: noble
+    components: contrib
+    base_path: fluentd/lts/6/ubuntu/noble/
+    short_name: ubuntu_noble_fluentd
+    sync_group: third_party
+    distribution_name: ubuntu-noble-fluentd-
+  # MariaDB 11.4 for Ubuntu Noble
+  - name: MariaDB 11.4 - Ubuntu Noble
+    url: https://dlm.mariadb.com/repo/mariadb-server/11.4/repo/ubuntu
+    distributions: noble
+    components: main
+    architectures: amd64
+    base_path: mariadb-server/mariadb-11.4/repo/ubuntu/
+    short_name: ubuntu_noble_mariadb_11_4
+    sync_group: third_party
+    distribution_name: mariadb-11.4-ubuntu-noble-
+
 
 # Default filter string for Deb package repositories.
 deb_package_repo_filter: ""


### PR DESCRIPTION
Repos needed to build 2026.1 kolla container images. Not many changes, most were added when we included RL10 support in the past

Checked against https://opendev.org/openstack/kolla/src/branch/stable/2026.1/kolla/template/repos.yaml