### PR TITLE
Add Gazpacho to UCA distributions

### DIFF
--- a/ansible/inventory/group_vars/all/deb-package-repos
+++ b/ansible/inventory/group_vars/all/deb-package-repos
@@ -27,7 +27,7 @@ deb_package_repos:
     policy: immediate
     architectures: amd64
     components: main
-    distributions: jammy-updates/caracal noble-updates/epoxy
+    distributions: jammy-updates/caracal noble-updates/epoxy noble-updates/gazpacho
     mirror: true
     mode: verbatim
     base_path: ubuntu-cloud-archive/


### PR DESCRIPTION
Missed one before, since it's not included in repos.yaml