### PR TITLE
Fix fluent repository definition

### DIFF
--- a/ansible/inventory/group_vars/all/deb-package-repos
+++ b/ansible/inventory/group_vars/all/deb-package-repos
@@ -268,9 +268,6 @@ deb_package_repos:
   - name: Fluentd - Ubuntu Noble
     url: https://fluentd.cdn.cncf.io/lts/6/ubuntu/noble
     policy: immediate
-    architectures: amd64
-    distributions: noble
-    components: contrib
     base_path: fluentd/lts/6/ubuntu/noble/
     short_name: ubuntu_noble_fluentd
     sync_group: third_party


### PR DESCRIPTION
Sync it with treasuredata repo - because currently we just synced empty directories.