### PR TITLE
grafana: Switch deb repo to verbatim mode

### DIFF
--- a/ansible/inventory/group_vars/all/deb-package-repos
+++ b/ansible/inventory/group_vars/all/deb-package-repos
@@ -227,6 +227,7 @@ deb_package_repos:
     policy: immediate
     distributions: stable
     components: main
+    mode: verbatim
     base_path: grafana/oss/apt/
     short_name: ubuntu_noble_grafana
     sync_group: grafana


### PR DESCRIPTION
Simple is too limited: Simple publishing forces everything into a single layout (default all), preventing you from separating packages into distinct suites (e.g., stable, testing) or components (e.g., main, contrib).

Since it's a 1:1 mirror - we should switch to verbatim which clones the upstream repo 1:1.