### PR TITLE
GT-1385: Add Ironic Python Agent Builder

### DIFF
--- a/ansible/inventory/group_vars/all/source-repositories
+++ b/ansible/inventory/group_vars/all/source-repositories
@@ -241,6 +241,13 @@ source_repositories:
     synced_releases:
       - "2023.1"
       - yoga
+  ironic-python-agent-builder:
+    synced_releases:
+      - "2025.1"
+    community_files:
+      - codeowners:
+          content: "{{ community_files.codeowners.openstack }}"
+          dest: ".github/CODEOWNERS"
   ironic-ui:
     synced_releases:
       - yoga

--- a/ansible/inventory/group_vars/all/source-repositories
+++ b/ansible/inventory/group_vars/all/source-repositories
@@ -241,6 +241,8 @@ source_repositories:
     synced_releases:
       - "2023.1"
       - yoga
+  # We can drop the IPA builder fork when this is merged:
+  # https://review.opendev.org/c/openstack/ironic-python-agent-builder/+/998333
   ironic-python-agent-builder:
     synced_releases:
       - "2025.1"

--- a/terraform/github/terraform.tfvars.json
+++ b/terraform/github/terraform.tfvars.json
@@ -69,6 +69,7 @@
       "horizon",
       "ironic",
       "ironic-python-agent",
+      "ironic-python-agent-builder",
       "ironic-ui",
       "keystone",
       "magnum",


### PR DESCRIPTION
We add this repo to pull in a backported fix
for IPA builder that fixes the IPA systemd
service not starting in Centos 10 Stream.

We use Centos 10 Stream because the Rocky10
image is not ready yet and it contains a
recent release of qemu-img that has a bugfix
for writing to 4k native drives / virtual
disks.

We can drop the fork when this is merged:
https://review.opendev.org/c/openstack/ironic-python-agent-builder/+/998333