### PR TITLE
Use ansible_facts to get iso8601_basic_short

### DIFF
--- a/ansible/inventory/group_vars/all/dev-pulp-repos
+++ b/ansible/inventory/group_vars/all/dev-pulp-repos
@@ -8,7 +8,7 @@
 #        matters if we make a distribution for an earlier repository version,
 #        when later ones have already been distributed. Alternatively we could
 #        forget ordering and use a random string.
-dev_pulp_distribution_version: "{{ ansible_date_time.iso8601_basic_short }}"
+dev_pulp_distribution_version: "{{ ansible_facts.date_time.iso8601_basic_short }}"
 
 ###############################################################################
 # Deb


### PR DESCRIPTION
Fixes the following deprecation warning:

[DEPRECATION WARNING]: INJECT_FACTS_AS_VARS default to `True` is deprecated, top-level facts will not be auto injected after the change. This feature will be removed from ansible-core version 2.24.