### PR TITLE
Disable SKC weekly upstream sync

### DIFF
--- a/ansible/inventory/group_vars/all/source-repositories
+++ b/ansible/inventory/group_vars/all/source-repositories
@@ -113,6 +113,8 @@ source_repositories:
       - yoga
     workflows:
       ignored_workflows:
+        default_branch_only:
+          - upstream-sync
         elsewhere:
           - tox
     workflow_args:


### PR DESCRIPTION
This reverts commit dc79b8d2a01cb64e279c314661dbbb4d4542b09e to disable the SKC weekly sync. The sync doesn't work and we haven't found time to fix it yet. Disabling it again until we do.

See also https://github.com/stackhpc/stackhpc-kayobe-config/pull/2456

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workflow settings to ignore the `upstream-sync` workflow on the default branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->