### PR TITLE
Try creating dist if it doesn't exist

### DIFF
--- a/ansible/test-pulp-repo-version-query.yml
+++ b/ansible/test-pulp-repo-version-query.yml
@@ -64,12 +64,48 @@
       register: pulp_rpm_dists_list
 
     - vars:
-        repo: "{{ pulp_deb_repos_list.repositories | selectattr('name', 'equalto', item.repository) | first }}"
-        pub: "{{ (pulp_deb_pubs_list.publications + pulp_deb_verbatim_pubs_list.publications) | selectattr('repository', 'equalto', repo.pulp_href) | stackhpc.pulp.sort_publications
-          | first }}"
-        dist: "{{ pulp_deb_dists_list.distributions | selectattr('publication', 'equalto', pub.pulp_href) | first }}"
+        repo_list: >-
+          {{ pulp_deb_repos_list.repositories
+             | selectattr('name', 'equalto', item.repository)
+             | list }}
+        repo: "{{ repo_list[0] if (repo_list | length > 0) else {} }}"
+        pubs: >-
+          {{ (pulp_deb_pubs_list.publications + pulp_deb_verbatim_pubs_list.publications)
+             | selectattr('repository', 'equalto', repo.get('pulp_href', ''))
+             | stackhpc.pulp.sort_publications | list }}
+        pub: "{{ pubs[0] if (pubs | length > 0) else {} }}"
+        base_name: "{{ item.name | regex_replace('-[0-9]{8}T[0-9]{6}$', '') }}"
+        safe_pattern: "^{{ base_name | regex_escape }}(-[0-9]{8}T[0-9]{6})?$"
+        existing_dists: >-
+          {{ pulp_deb_dists_list.distributions
+             | selectattr('publication', 'equalto', pub.get('pulp_href', ''))
+             | selectattr('name', 'match', safe_pattern)
+             | list }}
+        dist: "{{ existing_dists[0] if (existing_dists | length > 0) else {} }}"
 
       block:
+        - name: Ensure Deb distributions exist for latest publication
+          pulp.squeezer.deb_distribution:
+            pulp_url: "{{ pulp_url }}"
+            username: "{{ pulp_username }}"
+            password: "{{ pulp_password }}"
+            name: "{{ item.name }}"
+            base_path: "{{ item.base_path }}"
+            publication: "{{ pub.get('pulp_href') }}"
+            content_guard: "{{ item.content_guard | default(omit) }}"
+            state: present
+          loop: "{{ dev_pulp_distribution_deb }}"
+          loop_control:
+            label: "{{ item.repository }}"
+          when: (pub | length > 0) and (existing_dists | length == 0)
+
+        - name: Re-query Deb distributions (to capture newly created ones)
+          pulp.squeezer.deb_distribution:
+            pulp_url: "{{ pulp_url }}"
+            username: "{{ pulp_username }}"
+            password: "{{ pulp_password }}"
+          register: pulp_deb_dists_list
+
         - name: Display latest Deb distributions
           vars:
             info:
@@ -81,23 +117,66 @@
           loop: "{{ dev_pulp_distribution_deb }}"
           loop_control:
             label: "{{ item.repository }}"
+          when: pub | length > 0
 
         - name: Set a fact about latest Deb versions
           ansible.builtin.set_fact:
-            test_pulp_repository_deb_repo_versions: "{{ test_pulp_repository_deb_repo_versions | default({}) | combine({item.short_name: dist.base_path | basename})
-              }}"
+            test_pulp_repository_deb_repo_versions: >-
+              {{ test_pulp_repository_deb_repo_versions
+                 | default({})
+                 | combine({item.short_name: dist.base_path | basename}) }}
           loop: "{{ dev_pulp_distribution_deb }}"
           loop_control:
             label: "{{ item.repository }}"
+          when: dist | length > 0
 
         - name: Display latest versions fact
           ansible.builtin.debug:
             var: test_pulp_repository_deb_repo_versions
+
     - vars:
-        repo: "{{ pulp_rpm_repos_list.repositories | selectattr('name', 'equalto', item.repository) | first }}"
-        pub: "{{ pulp_rpm_pubs_list.publications | selectattr('repository', 'equalto', repo.pulp_href) | stackhpc.pulp.sort_publications | first }}"
-        dist: "{{ pulp_rpm_dists_list.distributions | selectattr('publication', 'equalto', pub.pulp_href) | first }}"
+        repo_list: >-
+          {{ pulp_rpm_repos_list.repositories
+             | selectattr('name', 'equalto', item.repository)
+             | list }}
+        repo: "{{ repo_list[0] if (repo_list | length > 0) else {} }}"
+        pubs: >-
+          {{ pulp_rpm_pubs_list.publications
+             | selectattr('repository', 'equalto', repo.get('pulp_href', ''))
+             | stackhpc.pulp.sort_publications | list }}
+        pub: "{{ pubs[0] if (pubs | length > 0) else {} }}"
+        base_name: "{{ item.name | regex_replace('-[0-9]{8}T[0-9]{6}$', '') }}"
+        safe_pattern: "^{{ base_name | regex_escape }}(-[0-9]{8}T[0-9]{6})?$"
+        existing_dists: >-
+          {{ pulp_rpm_dists_list.distributions
+             | selectattr('publication', 'equalto', pub.get('pulp_href', ''))
+             | selectattr('name', 'match', safe_pattern)
+             | list }}
+        dist: "{{ existing_dists[0] if (existing_dists | length > 0) else {} }}"
+
       block:
+        - name: Ensure RPM distributions exist for latest publication
+          pulp.squeezer.rpm_distribution:
+            pulp_url: "{{ pulp_url }}"
+            username: "{{ pulp_username }}"
+            password: "{{ pulp_password }}"
+            name: "{{ item.name }}"
+            base_path: "{{ item.base_path }}"
+            publication: "{{ pub.get('pulp_href') }}"
+            content_guard: "{{ item.content_guard | default(omit) }}"
+            state: present
+          loop: "{{ dev_pulp_distribution_rpm }}"
+          loop_control:
+            label: "{{ item.repository }}"
+          when: (pub | length > 0) and (existing_dists | length == 0)
+
+        - name: Re-query RPM distributions (to capture newly created ones)
+          pulp.squeezer.rpm_distribution:
+            pulp_url: "{{ pulp_url }}"
+            username: "{{ pulp_username }}"
+            password: "{{ pulp_password }}"
+          register: pulp_rpm_dists_list
+
         - name: Display latest RPM distributions
           vars:
             info:
@@ -109,14 +188,18 @@
           loop: "{{ dev_pulp_distribution_rpm }}"
           loop_control:
             label: "{{ item.repository }}"
+          when: pub | length > 0
 
         - name: Set a fact about latest RPM versions
           ansible.builtin.set_fact:
-            test_pulp_repository_rpm_repo_versions: "{{ test_pulp_repository_rpm_repo_versions | default({}) | combine({item.short_name: dist.base_path | basename})
-              }}"
+            test_pulp_repository_rpm_repo_versions: >-
+              {{ test_pulp_repository_rpm_repo_versions
+                 | default({})
+                 | combine({item.short_name: dist.base_path | basename}) }}
           loop: "{{ dev_pulp_distribution_rpm }}"
           loop_control:
             label: "{{ item.repository }}"
+          when: dist | length > 0
 
         - name: Display latest versions fact
           ansible.builtin.debug:


### PR DESCRIPTION
When generating package repo version list, create a distribution when it doesn't exist for some reason.