### PR TITLE
Stop magnum sync for 2025.1

### DIFF
--- a/ansible/inventory/group_vars/all/source-repositories
+++ b/ansible/inventory/group_vars/all/source-repositories
@@ -262,7 +262,6 @@ source_repositories:
           dest: ".github/CODEOWNERS"
   magnum:
     synced_releases:
-        - "2025.1"
         - "2024.1"
         - "2023.1"
         - zed


### PR DESCRIPTION
We are using upstream [1].

[1] https://github.com/stackhpc/stackhpc-kayobe-config/commit/61e9e9781c5d4cb0139075ad6e2bd638da01ea53