### PR TITLE
Bump actions defaults to 2026.1

### DIFF
--- a/.github/workflows/package-promote.yml
+++ b/.github/workflows/package-promote.yml
@@ -11,7 +11,7 @@ on:
       kayobe_config_branch:
         required: false
         description: Branch of StackHPC Kayobe configuration to use
-        default: stackhpc/2025.1
+        default: stackhpc/2026.1
       check_mode:
         description: Check mode
         type: boolean

--- a/.github/workflows/package-update-kayobe.yml
+++ b/.github/workflows/package-update-kayobe.yml
@@ -11,7 +11,7 @@ on:
       kayobe_config_branch:
         required: false
         description: Branch of StackHPC Kayobe configuration to use
-        default: stackhpc/2025.1
+        default: stackhpc/2026.1
 
 env:
   ANSIBLE_FORCE_COLOR: true


### PR DESCRIPTION
Just changes a few gh workflows so their default parameters are 2026.1 instead of 2025.1