### PR TITLE
Add httpd image

### DIFF
--- a/ansible/inventory/group_vars/all/kolla
+++ b/ansible/inventory/group_vars/all/kolla
@@ -44,6 +44,7 @@ kolla_container_images:
   - heat-base
   - heat-engine
   - horizon
+  - httpd
   - influxdb
   - ironic-api
   - ironic-base


### PR DESCRIPTION
httpd is a new image in Gazpacho & needs to be added to this list to ensure it is promoted to the stackhpc namespace on merge to SKC