### PR TITLE
Re enable required status checks on skc 2026.1

### DIFF
--- a/terraform/github/terraform.tfvars.json
+++ b/terraform/github/terraform.tfvars.json
@@ -412,7 +412,17 @@
       "stackhpc/2026.1": [
         "Tox pep8 with Python 3.12",
         "Tox releasenotes with Python 3.12",
-        "Tox docs with Python 3.12"
+        "Tox docs with Python 3.12",
+        "aio (Rocky 10 aarch64 OVN) / All in one",
+        "aio (Rocky 10 aarch64 OVS) / All in one",
+        "aio (Rocky 10 OVN) / All in one",
+        "aio (Rocky 10 OVS) / All in one",
+        "aio (Ubuntu Noble OVN) / All in one",
+        "aio upgrade (Rocky 10 OVN) / All in one",
+        "aio upgrade (Rocky 10 OVS) / All in one",
+        "aio upgrade (Ubuntu Noble OVN) / All in one",
+        "Ansible 2.19 lint with Python 3.12",
+        "Ansible 2.20 lint with Python 3.12"
       ],
       "stackhpc/master": [
         "Tox pep8 with Python 3.12",


### PR DESCRIPTION
Required status checks for stackhpc/2026.1 in SKC were disabled while the branch was under development. The branch is now main and in use, and the checks are passing, so it's time we re-enable them