### PR TITLE
Stop syncing EOL releases of Kolla deliverables

### DIFF
--- a/ansible/inventory/group_vars/all/source-repositories
+++ b/ansible/inventory/group_vars/all/source-repositories
@@ -55,9 +55,6 @@ source_repositories:
       - "2026.1"
       - "2025.1"
       - "2024.1"
-      - "2023.1"
-      - zed
-      - yoga
     community_files:
       - codeowners:
           content: "{{ community_files.codeowners.kayobe }}"
@@ -68,9 +65,6 @@ source_repositories:
       - "2026.1"
       - "2025.1"
       - "2024.1"
-      - "2023.1"
-      - zed
-      - yoga
     community_files:
       - codeowners:
           content: "{{ community_files.codeowners.kayobe }}"
@@ -88,9 +82,6 @@ source_repositories:
       - "2026.1"
       - "2025.1"
       - "2024.1"
-      - "2023.1"
-      - zed
-      - yoga
     community_files:
       - codeowners:
           content: "{{ community_files.codeowners.kayobe }}"
@@ -108,9 +99,6 @@ source_repositories:
       - "2026.1"
       - "2025.1"
       - "2024.1"
-      - "2023.1"
-      - zed
-      - yoga
     workflows:
       ignored_workflows:
         default_branch_only:


### PR DESCRIPTION
2023.1 and older are EOL in upstream Kolla projects.