### PR TITLE
Add Ceph Squid el9 repo from download.ceph.com

### DIFF
--- a/ansible/inventory/group_vars/all/rpm-package-repos
+++ b/ansible/inventory/group_vars/all/rpm-package-repos
@@ -403,6 +403,22 @@ rpm_package_repos:
     short_name: centos_stream_9_storage_ceph_squid_aarch64
     sync_group: rocky_9_aarch64
     distribution_name: centos-stream-9-storage-ceph-squid-aarch64-
+  # Ceph Squid for EL9, from Ceph upstream.
+  # NOTE(bbezak): The SIG only has Ceph Squid 19.2.5 for el9, which misses the
+  # 19.2.6 CVE fixes.
+  - name: Ceph Squid - el9
+    url: https://download.ceph.com/rpm-squid/el9/x86_64/
+    base_path: ceph/rpm-squid/el9/x86_64/
+    short_name: ceph_squid_el9
+    sync_group: third_party
+    distribution_name: ceph-squid-el9-
+  # Ceph Squid for EL9, from Ceph upstream (aarch64)
+  - name: Ceph Squid - el9 (aarch64)
+    url: https://download.ceph.com/rpm-squid/el9/aarch64/
+    base_path: ceph/rpm-squid/el9/aarch64/
+    short_name: ceph_squid_el9_aarch64
+    sync_group: rocky_9_aarch64
+    distribution_name: ceph-squid-el9-aarch64-
   # EPEL 9 repository
   - name: Extra Packages for Enterprise Linux 9
     url: https://mirrors.fedoraproject.org/mirrorlist?repo=epel-9&arch=x86_64&country=NL&infra=stock&content=centos&protocol=https


### PR DESCRIPTION
The CentOS Storage SIG only has Squid 19.2.5 for el9, which misses the 19.2.6 CVE fixes, so kolla takes the el9 Ceph packages from upstream.

el10 is fine, the SIG has 19.2.6 there, and there is no el10 on download.ceph.com for squid.

preparation for https://review.opendev.org/c/openstack/kolla/+/1002473