### PR TITLE
Bump dependencies

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -22,14 +22,10 @@ runs:
     # Install python dependencies for ansible server side
     - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
-        python-version: 3.11.x
+        python-version: 3.12.x
         # Cache Python dependencies
         cache: pip
-
-    - name: Install Python dependencies
-      run: |
-        pip install -r requirements.txt
-      shell: bash
+        pip-install: -r requirements.txt
 
     - name: Install Ansible collection dependencies
       run: |
@@ -48,5 +44,5 @@ runs:
     # everywhere. It's fine for CI purposes.
     - name: Install Python dependencies
       run: |
-        /usr/bin/python3 -m pip install setuptools --break-system-packages
+        /usr/bin/python3 -m pip install setuptools pulp-glue==0.33.* pulp-glue-deb==0.3.* --break-system-packages
       shell: bash

--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Install ansible-lint
         run: |
-          pip install ansible-core==2.20.* ansible-lint==26.*
+          pip install ansible-lint==26.*
 
       - name: Lint Ansible playbooks
         run: |

--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -20,15 +20,12 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
-          python-version: '3.12' 
+          python-version: '3.12'
+          pip-install: -r requirements.txt
 
       - name: Install Ansible collections
         run: |
           ansible-galaxy collection install -r requirements.yml
-
-      - name: Install pip dependencies
-        run: |
-          pip install -r requirements.txt
 
       - name: Install ansible-lint
         run: |

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,5 @@
-ansible<14
+ansible<14,>=13
 jmespath==0.10.0
+pulp-glue==0.33.*
+pulp-glue-deb==0.3.*
+setuptools

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,8 +1,6 @@
 ---
 collections:
   - name: stackhpc.pulp
-    version: 0.5.4
-  - name: community.crypto
-    version: 2.0.2
+    version: 0.6.0
   - name: pulp.squeezer
-    version: 0.0.13
+    version: 0.3.0


### PR DESCRIPTION
Bumps Ansible pulp collections (pulp squeezer and our downstream ansible-collection-pulp) to the same versions we currently use in SKC. These should come with bugfixes and performance improvements.

These now depend on pulp-glue and pulp-glue-deb pip packages, which have been added to requirements.txt

Initially marking as draft while I run through workflows to see what breaks