### PR TITLE
Add debug option to package update workflow

### DIFF
--- a/.github/workflows/package-update-kayobe.yml
+++ b/.github/workflows/package-update-kayobe.yml
@@ -12,6 +12,10 @@ on:
         required: false
         description: Branch of StackHPC Kayobe configuration to use
         default: stackhpc/2026.1
+      debug:
+        description: "Enable debug logging"
+        type: boolean
+        default: false
 
 env:
   ANSIBLE_FORCE_COLOR: true
@@ -44,7 +48,8 @@ jobs:
           ansible/test-kayobe-repo-version-generate.yml \
           -e deb_package_repo_filter="'$FILTER'" \
           -e rpm_package_repo_filter="'$FILTER'" \
-          -e kayobe_config_repo_path=./stackhpc-kayobe-config/
+          -e kayobe_config_repo_path=./stackhpc-kayobe-config/ \
+          -e release_train_debug=${{ github.event.inputs.debug }}
         env:
           FILTER: ${{ github.event.inputs.filter }}
 

--- a/ansible/inventory/group_vars/all/meta
+++ b/ansible/inventory/group_vars/all/meta
@@ -1,0 +1,3 @@
+---
+# Enable to print debug logs in release train workflows
+release_train_debug: false

--- a/ansible/kayobe-repo-version-query.yml
+++ b/ansible/kayobe-repo-version-query.yml
@@ -46,3 +46,5 @@
     - name: Display Kayobe Pulp repository versions
       ansible.builtin.debug:
         var: kayobe_pulp_repo_versions
+      when:
+        - release_train_debug | bool

--- a/ansible/test-pulp-repo-version-query.yml
+++ b/ansible/test-pulp-repo-version-query.yml
@@ -117,7 +117,9 @@
           loop: "{{ dev_pulp_distribution_deb }}"
           loop_control:
             label: "{{ item.repository }}"
-          when: pub | length > 0
+          when:
+            - release_train_debug | bool
+            - pub | length > 0
 
         - name: Set a fact about latest Deb versions
           ansible.builtin.set_fact:
@@ -133,6 +135,8 @@
         - name: Display latest versions fact
           ansible.builtin.debug:
             var: test_pulp_repository_deb_repo_versions
+          when:
+            - release_train_debug | bool
 
     - vars:
         repo_list: >-
@@ -188,7 +192,9 @@
           loop: "{{ dev_pulp_distribution_rpm }}"
           loop_control:
             label: "{{ item.repository }}"
-          when: pub | length > 0
+          when:
+            - release_train_debug | bool
+            - pub | length > 0
 
         - name: Set a fact about latest RPM versions
           ansible.builtin.set_fact:
@@ -204,3 +210,5 @@
         - name: Display latest versions fact
           ansible.builtin.debug:
             var: test_pulp_repository_rpm_repo_versions
+          when:
+            - release_train_debug | bool


### PR DESCRIPTION
Previously, we would print a bunch of debug output every time we ran the version query playbook. That output is slow, so this change hides it behind an input, so it's still an option but not the default. This takes runtime from 24 minutes to 20 minutes.

Added a general release_train_debug variable, so the pattern can be repeated in the future.
