### PR TITLE
Temporarily sync noble-proposed packages

### DIFF
--- a/ansible/inventory/group_vars/all/deb-package-repos
+++ b/ansible/inventory/group_vars/all/deb-package-repos
@@ -79,7 +79,9 @@ deb_package_repos:
     # path. This allows us to include security updates when using
     # DIB_DISTRIBUTION_MIRROR with the Diskimage builder ubuntu-minimal
     # element.
-    distributions: noble noble-updates noble-backports noble-security
+    # TODO(bbezak): Remove noble-proposed once Ceph 19.2.6 reaches
+    # noble-updates: https://bugs.launchpad.net/bugs/2161000
+    distributions: noble noble-updates noble-backports noble-security noble-proposed
     mirror: true
     mode: verbatim
     base_path: ubuntu/noble/


### PR DESCRIPTION
Ceph packages fixing CVE-2026-50152 [1] [2] are still in proposed and not yet available in noble-updates. Mirror them for Kolla builds and remove proposed once the fixed packages reach updates.

[1] https://ubuntu.com/security/CVE-2026-50152
[2] https://bugs.launchpad.net/ubuntu/+source/ceph/+bug/2161000

(only amd64, as we're not building aarch64 ubuntu kolla images)